### PR TITLE
Allow pre-populated dictionary to be passed to `load_bolometer_camera`

### DIFF
--- a/cherab/tools/observers/bolometry.py
+++ b/cherab/tools/observers/bolometry.py
@@ -533,20 +533,25 @@ class BolometerFoil(Node):
             print(self.detector_id, 'etendue {:.4G} +- {:.3G} m^2 str'.format(self.etendue, self.etendue_error))
 
 
-def load_bolometer_camera(filename, parent=None, inversion_grid=None):
+def load_bolometer_camera(filename, parent=None, inversion_grid=None, camera_dict=None):
 
-    name, extention = os.path.splitext(filename)
-
-    if extention == '.json':
-        file_handle = open(filename, 'r')
-        camera_state = json.load(file_handle)
-
-    elif extention == '.pickle':
-        file_handle = open(filename, 'rb')
-        camera_state = pickle.load(file_handle)
+    if filename == 'machine_description':
+        name, extention = '', ''
+        camera_state = camera_dict
 
     else:
-        raise IOError("Unrecognised CHERAB object file format - '{}'.".format(extention))
+        name, extention = os.path.splitext(filename)
+
+        if extention == '.json':
+            file_handle = open(filename, 'r')
+            camera_state = json.load(file_handle)
+
+        elif extention == '.pickle':
+            file_handle = open(filename, 'rb')
+            camera_state = pickle.load(file_handle)
+
+        else:
+            raise IOError("Unrecognised CHERAB object file format - '{}'.".format(extention))
 
     if not camera_state['CHERAB_Object_Type'] == 'BolometerCamera':
         raise ValueError("The selected json file does not contain a valid BolometerCamera description.")


### PR DESCRIPTION
This enables the Cherab object to be built using information from sources
other than JSON or pickle files, for example the MAST-U machine description.

N.B. The actual production of this dictionary from the MAST-U machine
description will be in `cherab_mastu`

	modified:   cherab/tools/observers/bolometry.py