### PR TITLE
Fix using 'sensitivity', renamed from 'etendue', in etendue calculation

### DIFF
--- a/cherab/tools/observers/bolometry.py
+++ b/cherab/tools/observers/bolometry.py
@@ -520,7 +520,7 @@ class BolometerFoil(Node):
 
             etendue_fraction = passed / ray_count
 
-            etendues.append(self._volume_observer.etendue * etendue_fraction)
+            etendues.append(self._volume_observer.sensitivity * etendue_fraction)
 
         self._etendue = np.mean(etendues)
         self._etendue_error = np.std(etendues)


### PR DESCRIPTION
A recent raysect update renamed the mis-named etendue property. This PR updates the etendue calculation in bolometry.py to reflect that.