### PR TITLE
Enable saving bolometer cameras in compressed pickle format

### DIFF
--- a/cherab/tools/observers/bolometry.py
+++ b/cherab/tools/observers/bolometry.py
@@ -20,6 +20,7 @@
 import os
 import json
 import pickle
+import gzip
 import numpy as np
 
 from raysect.core import Node, translate, rotate_basis, Point3D, Vector3D, Ray as CoreRay, Primitive
@@ -149,6 +150,10 @@ class BolometerCamera(Node):
         elif extention == '.pickle':
             file_handle = open(filename, 'wb')
             pickle.dump(self.__getstate__(serialisation_format=extention), file_handle)
+
+        elif extention == '.pgz':
+            with gzip.open(filename, 'wb') as file_handle:
+                pickle.dump(self.__getstate__(serialisation_format='.pickle'), file_handle)
 
         elif extention == '.sav':
             import idlbridge as idl


### PR DESCRIPTION
Bolometer sensitivity matrices are typically sparse, and so
compress very well. Compressing the pickle file a camera is
saved in can therefore result in significant space savings.
The file extension proposed is .pgz, analogous to .tgz for
tarballs also compressed with gzip.

This is particularly relevant in the following use case: split
a sensitivity calculation on a large grid into many separate jobs,
each of which calculates only a subset of the grid. Write an output
pickle file for each job, in which the sensitivity matrix is all zeros
and only the indices of the grid cells involved in the job are
updated. In post processing, sum the matrices for all the separate
jobs to get the total sensitivity for the grid. In this case, having
many uncompressed pickle files is extremely space inefficient, and
can even lead to storage quota issues if enough jobs are run.
Compressing the intermediate pickle files mitigates this issue.