### PR TITLE
 Add option to calculate bolometer sensitivities for a subset of grid cells

### DIFF
--- a/cherab/tools/observers/bolometry.py
+++ b/cherab/tools/observers/bolometry.py
@@ -439,16 +439,12 @@ class BolometerFoil(Node):
             r_inner = p1.x
             r_outer = p3.x
             if r_inner > r_outer:
-                t = r_inner
-                r_inner = r_outer
-                r_outer = t
+                r_inner, r_outer = r_outer, r_inner
 
             z_lower = p2.y
             z_upper = p1.y
             if z_lower > z_upper:
-                t = z_lower
-                z_lower = z_upper
-                z_upper = t
+                z_lower, z_upper = z_upper, z_lower
 
             # TODO - switch to using CAD method such that reflections can be included automatically
             cylinder_height = z_upper - z_lower

--- a/cherab/tools/observers/bolometry.py
+++ b/cherab/tools/observers/bolometry.py
@@ -420,7 +420,7 @@ class BolometerFoil(Node):
         self._volume_observer.pixel_samples = cached_sample_rate
         return self._volume_power_pipeline.value.mean
 
-    def calculate_sensitivity(self, grid):
+    def calculate_sensitivity(self, grid, cell_range=None):
 
         world = self.root
 
@@ -432,7 +432,10 @@ class BolometerFoil(Node):
         wvl_range = self._volume_observer.max_wavelength - self._volume_observer.min_wavelength
         emitter = UniformVolumeEmitter(ConstantSF(1/wvl_range))
 
-        for i in range(grid.count):
+        if cell_range is None:
+            cell_range = range(grid.count)
+
+        for i in cell_range:
 
             p1, p2, p3, p4 = grid[i]
 


### PR DESCRIPTION
For particularly large grids, significant parallel speedups can be made
by breaking the grid into separate chunks and calculating the sensitivities
of the cells in these chunks in parallel jobs. This commit modifies the
calculate_sensitivity method to allow scripts which require this feature
to specify which subset of the grid a particular job should calculate.

It is left to the calling software to handle splitting the calculation
and combining the result.