### PR TITLE
Enable RectangularGrid to be pickled and unpickled

### DIFF
--- a/cherab/tools/observers/inversion_grid.pyx
+++ b/cherab/tools/observers/inversion_grid.pyx
@@ -98,6 +98,12 @@ cdef class RectangularGrid:
 
         return state
 
+    def __setstate__(self, state):
+        grid_id = state['Grid_ID']
+        cell_data = np.asarray([[cell['p1'], cell['p2'], cell['p3'], cell['p4']]
+                                for cell in state['cells']])
+        self.__init__(grid_id, cell_data)
+
     def cell_area(self, cell_index):
         p1, p2, p3, p4 = self.__getitem__(cell_index)
         return cabs((p3.x - p2.x) * (p2.y - p1.y))


### PR DESCRIPTION
This means we can pass RectangularGrid objects to worker processes
in multiprocessing and MPI applications, rather than requiring the
grid to be in the global namespace.