### PR TITLE
Add support for describing Axisymmetric voxels using CSG

### DIFF
--- a/cherab/tools/inversions/voxels.pyx
+++ b/cherab/tools/inversions/voxels.pyx
@@ -24,12 +24,13 @@ import matplotlib.pyplot as plt
 from matplotlib.patches import Polygon
 from matplotlib.collections import PatchCollection
 
-from raysect.core cimport Node, Point2D, Point3D, Vector3D, rotate_z, AffineMatrix3D, new_point3d
-from raysect.core.math cimport triangulate2d
+from raysect.core cimport (Node, Point2D, Vector2D, Point3D, Vector3D,
+                           rotate_z, AffineMatrix3D, new_point3d)
+from raysect.core.math cimport triangulate2d, translate, rotate_basis
 from raysect.core.math.function cimport Function3D
 from raysect.core.math.cython.utility cimport winding2d, find_index
 from raysect.core.math.random cimport uniform, point_triangle
-from raysect.primitive import Mesh
+from raysect.primitive import Mesh, Cylinder, Cone, Intersect, Subtract, Union
 from raysect.optical import UnityVolumeEmitter
 from raysect.optical cimport Spectrum, World, Primitive, Ray
 from raysect.optical.material.emitter.homogeneous cimport HomogeneousVolumeEmitter
@@ -49,7 +50,7 @@ class AxisymmetricVoxel(Voxel):
 
     # cdef np.ndarray _vertices, _triangles
 
-    def __init__(self, vertices, parent=None, material=None):
+    def __init__(self, vertices, parent=None, material=None, primitive_type='mesh'):
 
         super().__init__(parent=parent)
 
@@ -69,8 +70,25 @@ class AxisymmetricVoxel(Voxel):
         if not winding2d(self._vertices):
             self._vertices = self._vertices[::-1]
 
+        self._triangles = triangulate2d(self._vertices)
+
         # Generate summary statistics
         self.radius = self._vertices[:, 0].sum()/num_vertices
+
+        if primitive_type == 'mesh':
+            self._build_mesh()
+        elif primitive_type == 'csg':
+            if self._has_rectangular_cross_section():
+                self._build_csg_from_rectangle()
+            else:
+                for triangle in self._triangles:
+                    self._build_csg_from_triangle(self._vertices[triangle])
+        else:
+            raise ValueError("primitive_type should be 'mesh' or 'csg'")
+
+    def _build_mesh(self):
+        """Build the Voxel out of triangular mesh elements."""
+        num_vertices = len(self._vertices)
         radial_width = self._vertices[:, 0].max() - self._vertices[:, 0].min()
 
         number_segments = int(floor(2 * PI * self.radius / radial_width))
@@ -91,8 +109,6 @@ class AxisymmetricVoxel(Voxel):
             vertices.append([p.x, p.y, p.z])
         for p in rotated_points:
             vertices.append([p.x, p.y, p.z])
-
-        self._triangles = triangulate2d(self._vertices)
 
         # assemble mesh triangles
         triangles = []
@@ -117,6 +133,108 @@ class AxisymmetricVoxel(Voxel):
         for i in range(number_segments):
             theta_rotation = theta_adjusted * i
             segment = base_segment.instance(transform=rotate_z(theta_rotation), material=self._material, parent=self)
+
+    def _has_rectangular_cross_section(self):
+        """
+        Test if the voxel has a rectangular cross section, and is aligned with
+        the coordinate axes.
+        """
+        if len(self.vertices) != 4:
+            return False
+        # A rectangle (including a square, which is considered to have a
+        # rectangular cross section too) is defined by having equal length
+        # diagonals.
+        distance_13 = self.vertices[0].distance_to(self.vertices[2])
+        distance_24 = self.vertices[1].distance_to(self.vertices[3])
+        if distance_13 != distance_24:
+            return False
+        # The rectangle should be aligned with the coordinate axes, i.e. the
+        # edge from vertex 1 to 2 should be parallel to either the x or z axes.
+        side_12 = self.vertices[0].vector_to(self.vertices[1])
+        if side_12.dot(Vector2D(1, 0)) != 0 and side_12.dot(Vector2D(0, 1)) != 0:
+            return False
+        return True
+
+    def _build_csg_from_triangle(self, vertices):
+        if vertices.shape != (3, 2):
+            raise ValueError("Vertices must be an array of 3 (x, z) coordinates")
+        # Sort the vertices of the triangle in decreasing x
+        # Vertex 1 is at largest x, vertex 2 is middle x, vertex 3 is smallest x
+        sort_inds = np.argsort(vertices[:, 0])[::-1]
+        vertices = vertices[sort_inds]
+        vertex_rs = vertices[:, 0]
+        vertex_zs = vertices[:, 1]
+        # Create a bounding ring around the vertices, with rectangular cross section
+        box_rmax = max(vertex_rs)
+        box_rmin = min(vertex_rs)
+        box_zmax = max(vertex_zs)
+        box_zmin = min(vertex_zs)
+        cylinder_height = box_zmax - box_zmin
+        outer_cylinder = Cylinder(radius=box_rmax, height=cylinder_height,
+                                  transform=translate(0, 0, box_zmin))
+        inner_cylinder = Cylinder(radius=box_rmin, height=cylinder_height,
+                                  transform=translate(0, 0, box_zmin))
+        bounding_ring = Subtract(outer_cylinder, inner_cylinder)
+
+        def create_cone(rx, zx, ry, zy):
+            if zx == zy:
+                return None
+            if rx == ry:
+                return Cylinder(radius=rx, height=abs(zx - zy),
+                                transform=translate(0, 0, min(zx, zy)))
+            if rx < ry:
+                raise ValueError('rx must be larger than ry')
+            if zx > zy:
+                transform = translate(0, 0, zx) * rotate_basis(Vector3D(0, 0, -1),
+                                                               Vector3D(0, 1, 0))
+            else:
+                transform = translate(0, 0, zx)
+            rcone = rx
+            hcone = abs(zx - zy) * rx / (rx - ry)
+            cone = Cone(radius=rcone, height=hcone, transform=transform)
+            return cone
+
+        r1, r2, r3 = vertex_rs
+        z1, z2, z3 = vertex_zs
+        cone13 = create_cone(r1, z1, r3, z3)
+        cone12 = create_cone(r1, z1, r2, z2)
+        cone23 = create_cone(r2, z2, r3, z3)
+        if z2 <= z1 <= z3 or z3 <= z1 <= z2:
+            voxel_element = Intersect(Subtract(Union(cone12, cone13), cone23), bounding_ring)
+        elif z1 <= z2 <= z3 and r1 != r2 != r3:
+            # Requires slightly different treatment, with a different bounding ring
+            outer_cylinder = Cylinder(radius=r1, height=z2 - z1, transform=translate(0, 0, z1))
+            inner_cylinder = Cylinder(radius=r3, height=z2 - z1, transform=translate(0, 0, z1))
+            bounding_ring = Subtract(outer_cylinder, inner_cylinder)
+            voxel_element = Intersect(Subtract(cone12, cone13), Union(bounding_ring, cone23))
+        elif r1 == r2 and z3 >= z2 and z3 >= z1:
+            if z1 >= z2:
+                voxel_element = Intersect(Subtract(Union(cone12, cone13), cone23), bounding_ring)
+            else:
+                voxel_element = Intersect(Subtract(Union(cone12, cone23), cone13), bounding_ring)
+        else:
+            if abs(z1 - z2) >= abs(z1 - z3):
+                voxel_element = Intersect(Subtract(Subtract(cone12, cone13), cone23), bounding_ring)
+            else:
+                voxel_element = Intersect(Subtract(Subtract(cone13, cone12), cone23), bounding_ring)
+
+        voxel_element.parent = self
+        voxel_element.material = self._material
+
+    def _build_csg_from_rectangle(self):
+        rmax = max(self._vertices[:, 0])
+        rmin = min(self._vertices[:, 0])
+        zmax = max(self._vertices[:, 1])
+        zmin = min(self._vertices[:, 1])
+        cylinder_height = zmax - zmin
+        cylinder_transform = translate(0, 0, zmin)
+        outer_cylinder = Cylinder(radius=rmax, height=cylinder_height,
+                                  transform=cylinder_transform)
+        inner_cylinder = Cylinder(radius=rmin, height=cylinder_height,
+                                  transform=cylinder_transform)
+        voxel = Subtract(outer_cylinder, inner_cylinder)
+        voxel.parent = self
+        voxel.material = self._material
 
     @property
     def material(self):
@@ -234,7 +352,9 @@ class ToroidalVoxelGrid(VoxelCollection):
     #     double _min_radius, _max_radius
     #     double _min_height, _max_height
 
-    def __init__(self, voxel_coordinates, name='', parent=None, transform=None, active="all"):
+
+    def __init__(self, voxel_coordinates, name='', parent=None, transform=None,
+                 active="all", primitive_type='mesh'):
 
         super().__init__(name=name, parent=parent, transform=transform)
 
@@ -246,7 +366,7 @@ class ToroidalVoxelGrid(VoxelCollection):
         self._voxels = []
         for i, voxel_vertices in enumerate(voxel_coordinates):
 
-            voxel = AxisymmetricVoxel(voxel_vertices)
+            voxel = AxisymmetricVoxel(voxel_vertices, primitive_type=primitive_type)
             if active == "all" or active == i:
                 voxel.parent = parent
             self._voxels.append(voxel)

--- a/cherab/tools/tests/test_voxels.py
+++ b/cherab/tools/tests/test_voxels.py
@@ -1,0 +1,169 @@
+# Copyright 2016-2018 Euratom
+# Copyright 2016-2018 United Kingdom Atomic Energy Authority
+# Copyright 2016-2018 Centro de Investigaciones Energéticas, Medioambientales y Tecnológicas
+#
+# Licensed under the EUPL, Version 1.1 or – as soon they will be approved by the
+# European Commission - subsequent versions of the EUPL (the "Licence");
+# You may not use this work except in compliance with the Licence.
+# You may obtain a copy of the Licence at:
+#
+# https://joinup.ec.europa.eu/software/page/eupl5
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied.
+#
+# See the Licence for the specific language governing permissions and limitations
+# under the Licence.
+
+import itertools
+import unittest
+
+from matplotlib.patches import Polygon
+from matplotlib.path import Path
+import numpy as np
+
+from raysect.core import Point2D, Point3D
+from cherab.tools.inversions import AxisymmetricVoxel
+
+TRIANGLE_VOXEL_COORDS = [
+    # Triangles with all vertices having different R and z
+    # First leaf
+    [(4, 3), (3, 2), (2, -1)],
+    [(4, 3), (3, -1), (2, -1)],
+    [(4, 3), (3, 3), (2, -1)],
+    # Second leaf
+    [(4, 3), (3, -1), (2, 2)],
+    [(4, 3), (3, 2), (2, 2)],
+    [(4, 3), (3, -1), (2, 3)],
+    # Third leaf
+    [(4, 2), (3, -1), (2, 3)],
+    [(4, -1), (3, -1), (2, 3)],
+    [(4, 3), (3, -1), (2, 3)],
+    # Fourth leaf
+    [(4, 2), (3, 3), (2, -1)],
+    [(4, -1), (3, 3), (2, -1)],
+    [(4, 3), (3, 3), (2, -1)],
+    # Fifth leaf
+    [(4, -1), (3, 3), (2, 2)],
+    [(4, -1), (3, 3), (2, -1)],
+    [(4, -1), (3, 3), (2, 3)],
+    # Sixth leaf
+    [(4, -1), (3, 2), (2, 3)],
+    [(4, -1), (3, -1), (2, 3)],
+    [(4, -1), (3, 3), (2, 3)],
+    # Triangles with horizontal or vertical edges (e.g. from rectilinear cells)
+    # R1 = R2 > R3
+    # First leaf
+    [(4, 3), (4, 2), (2, -1)],
+    [(4, 3), (4, -1), (2, -1)],
+    [(4, 3), (4, 3), (2, -1)], # Should produce zero volume voxel
+    # Second leaf
+    [(4, 3), (4, -1), (2, 2)],
+    [(4, 3), (4, -1), (2, -1)],
+    [(4, 3), (4, -1), (2, 3)],
+    # Third leaf
+    [(4, 2), (4, -1), (2, 3)],
+    [(4, -1), (4, -1), (2, 3)], # Should produce zero volume voxel
+    [(4, 3), (4, -1), (2, 3)],
+    # Fourth leaf
+    [(4, 2), (4, 3), (2, -1)],
+    [(4, -1), (4, 3), (2, -1)],
+    [(4, 3), (4, 3), (2, -1)], # Should produce zero volume voxel
+    # Fifth leaf
+    [(4, -1), (4, 3), (2, 2)],
+    [(4, -1), (4, 3), (2, -1)],
+    [(4, -1), (4, 3), (2, 3)],
+    # Sixth leaf
+    [(4, -1), (4, 2), (2, 3)],
+    [(4, -1), (4, 3), (2, 3)],
+    [(4, -1), (4, -1), (2, 3)], # Should produce zero volume voxel
+    # R1 > R2 = R3
+    # First leaf
+    [(4, 3), (2, 2), (2, -1)],
+    [(4, 3), (2, -1), (2, -1)], # Should produce zero volume voxel
+    [(4, 3), (2, 3), (2, -1)],
+    # Second leaf
+    [(4, 3), (2, -1), (2, 2)],
+    [(4, 3), (2, -1), (2, -1)], # Should produce zero volume voxel
+    [(4, 3), (2, -1), (2, 3)],
+    # Third leaf
+    [(4, 2), (2, -1), (2, 3)],
+    [(4, -1), (2, -1), (2, 3)],
+    [(4, 3), (2, -1), (2, 3)],
+    # Fourth leaf
+    [(4, 2), (2, 3), (2, -1)],
+    [(4, -1), (2, 3), (2, -1)],
+    [(4, 3), (2, 3), (2, -1)],
+    # Fifth leaf
+    [(4, -1), (2, 3), (2, 2)],
+    [(4, -1), (2, 3), (2, -1)],
+    [(4, -1), (2, 3), (2, 3)], # Should produce zero volume voxel
+    # Sixth leaf
+    [(4, -1), (2, 2), (2, 3)],
+    [(4, -1), (2, -1), (2, 3)],
+    [(4, -1), (2, 3), (2, 3)], # Should produce zero volume voxel
+]
+
+RECTANGULAR_VOXEL_COORDS = [
+    [(2, -1), (2, 3), (4, 3), (4, -1)],
+]
+
+ARBITRARY_VOXEL_COORDS = [
+    [(2, -1), (2, 2), (3, 4), (4, 3), (4, -1)],
+    [(2, -1), (2, 2), (3, 4), (4, 3), (4, 0)],
+    [(2, -1), (2, 2), (3, 4), (4, 3), (5, 0)],
+]
+
+class TestCSGVoxels(unittest.TestCase):
+    """Test cases for CSG voxels.
+
+    The basic test is as follows: for a list of voxel vertex coordinates,
+    generate the CSG representation of that Axisymmetric voxel. Then
+    generate a 2D polygon of the same cross section independently, using
+    Matplotlib. If the voxel has the correct cross section shape, then
+    the set of points (r, 0, z) which lie inside the voxel should be the
+    same as the set of points (r, z) which lie inside the 2D polygon.
+
+    So far, there are tests for triangular, rectangular and pentagonal voxels.
+    In principle, any arbitrary shape could be tested, but if the triangular
+    voxels are working correctly then arbitrary polygons will also work
+    correctly, as arbitrary shapes are implemented as a union of triangles.
+    """
+    def voxel_matches_polygon(self, coordinate_list):
+        for voxel_coords in coordinate_list:
+            voxel_coords = np.asarray(voxel_coords)
+            rmax = voxel_coords[:, 0].max()
+            rmin = voxel_coords[:, 0].min()
+            zmax = voxel_coords[:, 1].max()
+            zmin = voxel_coords[:, 1].min()
+            router = 1.5 * rmax
+            rinner = 0.5 * rmin
+            zupper = 1.5 * zmax if zmax > 0 else 0.5 * zmax
+            zlower = 0.5 * zmin if zmin > 0 else 1.5 * zmin
+            test_rs = np.linspace(rinner, router, int(100*(router-rinner)))
+            test_zs = np.linspace(zlower, zupper, int(100*(zupper-zlower)))
+            voxel_vertex_points = [Point2D(*v) for v in voxel_coords]
+            voxel = AxisymmetricVoxel(voxel_vertex_points, parent=None,
+                                      primitive_type='csg')
+            polygon = Polygon(voxel_coords, closed=True)
+            test_verts = list(itertools.product(test_rs, test_zs))
+            try:
+                inside_poly = polygon.contains_points(test_verts)
+            except AttributeError:
+                # Polygon.contains_points was only introduced in Matplotlib 2.2.
+                # Before that we need to convert to Path
+                inside_poly = Path(polygon.get_verts()).contains_points(test_verts)
+            inside_csg = [any(child.contains(Point3D(r, 0, z)) for child in voxel.children)
+                          for (r, z) in test_verts]
+            self.assertSequenceEqual(inside_csg, inside_poly.tolist())
+
+    def test_triangular_voxels(self):
+        self.voxel_matches_polygon(TRIANGLE_VOXEL_COORDS)
+
+    def test_rectangular_voxels(self):
+        self.voxel_matches_polygon(RECTANGULAR_VOXEL_COORDS)
+
+    def test_arbitrary_voxels(self):
+        self.voxel_matches_polygon(ARBITRARY_VOXEL_COORDS)
+


### PR DESCRIPTION
Using CSG primitives to describe Axisymmetric voxels results in
significantly lower memory usage than using meshes. The difference is
particularly pronounced for voxels with a radial width significantly
less than the mean radius of the voxel. For example, for a grid of
voxels of major radius ~1m on average:
- voxel width 5cm, CSG uses 6% the memory of mesh
- voxel width 2cm, CSG uses 2% the memory of mesh
- voxel width 2mm, 750k cell grid uses ~4.5GB of memory (mesh grid doesn't
  fit into memory on 128GB node, but a ~5000-cell subset uses ~8GB)

The reduction in memory usage makes it easier to work with high-voxel-count
grids, since they do not need to be split up. The CSG forumlation reduces the
child count of the voxels, which in turn speeds up pickling them and reduces
the file size of pickle save files.

Voxels with arbitrary polygon-shaped cross sections are supported, by splitting
the cross section into triangles. Each sub-triangle is used to form a toroidally-
symmetric sub-voxel using CSG operations on cylinders and cones, and these
sub-voxels are made children of the parent voxel.

The use of cone primitives does impact performance, as the KD tree is less
able to optimize ray tracing operations if the height of the cones are larger
than the resulting CSG voxel. As a performance enhancement, rectangular voxels
with edges on the x and z axes are given special treatment: instead of being
split into triangles, these are implemented as the subtraction of 2 cylinders.
This means that for voxel grids composed mainly of rectangular cells, with
perhaps non-rectangular or non-aligned cells at the edges of the grid, performance
is similar to the mesh formulation (but with significantly reduced memory overhead).

The choice of formulation (mesh or CSG) is chosen when the voxel is instantiated,
and defaults to mesh to maintain previous behaviour.

Also included are a series of tests. The principle of the tests is simple:
generate a series of points (r_i, 0, z_i), and check that the set of these
points which lie inside the voxel matches the set of points (r_i, z_i) which
lie in a 2D polygon of the same cross section. All possible triangle shapes
are tested, as well as a few extra cases of rectangular and pentagonal shapes.