### PR TITLE
Fix voxel grid plotting colourbar logic

### DIFF
--- a/cherab/tools/inversions/voxels.pyx
+++ b/cherab/tools/inversions/voxels.pyx
@@ -535,7 +535,7 @@ class ToroidalVoxelGrid(VoxelCollection):
             fig, ax = plt.subplots()
         ax.add_collection(p)
         fig = plt.gcf()
-        if voxel_values:
+        if p.get_array() is not None:
             fig.colorbar(p, ax=ax)
         ax.set_xlim(self.min_radius, self.max_radius)
         ax.set_ylim(self.min_height, self.max_height)


### PR DESCRIPTION
Plotting a voxel collection previously would fail on Python 3.7 with
Numpy 1.15.4 with a "truth table of an array is ambiguous" error when
voxel_values were supplied as a Numpy array. The test should be for
the colours being present, rather than indirectly via the voxel_values
being present.