### PR TITLE
Refactoring the variable name 'ionisation' to be 'charge' in the

### DIFF
--- a/cherab/core/atomic/interface.pxd
+++ b/cherab/core/atomic/interface.pxd
@@ -22,30 +22,30 @@ from cherab.core.atomic.rates cimport *
 
 cdef class AtomicData:
 
-    cpdef double wavelength(self, Element ion, int ionisation, tuple transition)
+    cpdef double wavelength(self, Element ion, int charge, tuple transition)
 
-    cpdef IonisationRate ionisation_rate(self, Element ion, int ionisation)
+    cpdef IonisationRate ionisation_rate(self, Element ion, int charge)
 
-    cpdef RecombinationRate recombination_rate(self, Element ion, int ionisation)
+    cpdef RecombinationRate recombination_rate(self, Element ion, int charge)
 
-    cpdef list beam_cx_pec(self, Element donor_ion, Element receiver_ion, int receiver_ionisation, tuple transition)
+    cpdef list beam_cx_pec(self, Element donor_ion, Element receiver_ion, int receiver_charge, tuple transition)
 
-    cpdef BeamStoppingRate beam_stopping_rate(self, Element beam_ion, Element plasma_ion, int ionisation)
+    cpdef BeamStoppingRate beam_stopping_rate(self, Element beam_ion, Element plasma_ion, int charge)
 
-    cpdef BeamPopulationRate beam_population_rate(self, Element beam_ion, int metastable, Element plasma_ion, int ionisation)
+    cpdef BeamPopulationRate beam_population_rate(self, Element beam_ion, int metastable, Element plasma_ion, int charge)
 
-    cpdef BeamEmissionPEC beam_emission_pec(self, Element beam_ion, Element plasma_ion, int ionisation, tuple transition)
+    cpdef BeamEmissionPEC beam_emission_pec(self, Element beam_ion, Element plasma_ion, int charge, tuple transition)
 
-    cpdef ImpactExcitationPEC impact_excitation_pec(self, Element ion, int ionisation, tuple transition)
+    cpdef ImpactExcitationPEC impact_excitation_pec(self, Element ion, int charge, tuple transition)
 
-    cpdef RecombinationPEC recombination_pec(self, Element ion, int ionisation, tuple transition)
+    cpdef RecombinationPEC recombination_pec(self, Element ion, int charge, tuple transition)
 
     cpdef TotalRadiatedPower total_radiated_power(self, Element element)
 
-    cpdef LineRadiationPower line_radiated_power_rate(self, Element element, int ionisation)
+    cpdef LineRadiationPower line_radiated_power_rate(self, Element element, int charge)
 
-    cpdef ContinuumPower continuum_radiated_power_rate(self, Element element, int ionisation)
+    cpdef ContinuumPower continuum_radiated_power_rate(self, Element element, int charge)
 
-    cpdef CXRadiationPower cx_radiated_power_rate(self, Element element, int ionisation)
+    cpdef CXRadiationPower cx_radiated_power_rate(self, Element element, int charge)
 
-    cpdef FractionalAbundance fractional_abundance(self, Element ion, int ionisation)
+    cpdef FractionalAbundance fractional_abundance(self, Element ion, int charge)

--- a/cherab/core/atomic/interface.pyx
+++ b/cherab/core/atomic/interface.pyx
@@ -25,65 +25,65 @@ cdef class AtomicData:
     atomic data.
     """
 
-    cpdef double wavelength(self, Element ion, int ionisation, tuple transition):
+    cpdef double wavelength(self, Element ion, int charge, tuple transition):
         """
         Returns the natural wavelength of the specified transition in nm.
         """
 
         raise NotImplementedError("The wavelength() virtual method is not implemented for this atomic data source.")
 
-    cpdef IonisationRate ionisation_rate(self, Element ion, int ionisation):
+    cpdef IonisationRate ionisation_rate(self, Element ion, int charge):
         raise NotImplementedError("The ionisation_rate() virtual method is not implemented for this atomic data source.")
 
-    cpdef RecombinationRate recombination_rate(self, Element ion, int ionisation):
+    cpdef RecombinationRate recombination_rate(self, Element ion, int charge):
         raise NotImplementedError("The recombination_rate() virtual method is not implemented for this atomic data source.")
 
-    cpdef list beam_cx_pec(self, Element donor_ion, Element receiver_ion, int receiver_ionisation, tuple transition):
+    cpdef list beam_cx_pec(self, Element donor_ion, Element receiver_ion, int receiver_charge, tuple transition):
         """
         Returns a list of applicable charge exchange emission rates in W.m^3.
         """
 
         raise NotImplementedError("The cxs_rates() virtual method is not implemented for this atomic data source.")
 
-    cpdef BeamStoppingRate beam_stopping_rate(self, Element beam_ion, Element plasma_ion, int ionisation):
+    cpdef BeamStoppingRate beam_stopping_rate(self, Element beam_ion, Element plasma_ion, int charge):
         """
         Returns a list of applicable beam stopping coefficients in m^3/s.
         """
 
         raise NotImplementedError("The beam_stopping() virtual method is not implemented for this atomic data source.")
 
-    cpdef BeamPopulationRate beam_population_rate(self, Element beam_ion, int metastable, Element plasma_ion, int ionisation):
+    cpdef BeamPopulationRate beam_population_rate(self, Element beam_ion, int metastable, Element plasma_ion, int charge):
         """
         Returns a list of applicable beam population coefficients in m^3/s.
         """
 
         raise NotImplementedError("The beam_population() virtual method is not implemented for this atomic data source.")
 
-    cpdef BeamEmissionPEC beam_emission_pec(self, Element beam_ion, Element plasma_ion, int ionisation, tuple transition):
+    cpdef BeamEmissionPEC beam_emission_pec(self, Element beam_ion, Element plasma_ion, int charge, tuple transition):
         """
         Returns a list of applicable beam emission coefficients in W.m^3.
         """
 
         raise NotImplementedError("The beam_emission() virtual method is not implemented for this atomic data source.")
 
-    cpdef ImpactExcitationPEC impact_excitation_pec(self, Element ion, int ionisation, tuple transition):
+    cpdef ImpactExcitationPEC impact_excitation_pec(self, Element ion, int charge, tuple transition):
         raise NotImplementedError("The impact_excitation() virtual method is not implemented for this atomic data source.")
 
-    cpdef RecombinationPEC recombination_pec(self, Element ion, int ionisation, tuple transition):
+    cpdef RecombinationPEC recombination_pec(self, Element ion, int charge, tuple transition):
         raise NotImplementedError("The recombination() virtual method is not implemented for this atomic data source.")
 
     cpdef TotalRadiatedPower total_radiated_power(self, Element element):
         raise NotImplementedError("The total_radiated_power() virtual method is not implemented for this atomic data source.")
 
-    cpdef LineRadiationPower line_radiated_power_rate(self, Element element, int ionisation):
+    cpdef LineRadiationPower line_radiated_power_rate(self, Element element, int charge):
         raise NotImplementedError("The line_radiated_power_rate() virtual method is not implemented for this atomic data source.")
 
-    cpdef ContinuumPower continuum_radiated_power_rate(self, Element element, int ionisation):
+    cpdef ContinuumPower continuum_radiated_power_rate(self, Element element, int charge):
         raise NotImplementedError("The continuum_radiated_power_rate() virtual method is not implemented for this atomic data source.")
 
-    cpdef CXRadiationPower cx_radiated_power_rate(self, Element element, int ionisation):
+    cpdef CXRadiationPower cx_radiated_power_rate(self, Element element, int charge):
         raise NotImplementedError("The cx_radiated_power_rate() virtual method is not implemented for this atomic data source.")
 
-    cpdef FractionalAbundance fractional_abundance(self, Element ion, int ionisation):
+    cpdef FractionalAbundance fractional_abundance(self, Element ion, int charge):
         raise NotImplementedError("The fractional_abundance() virtual method is not implemented for this atomic data source.")
 

--- a/cherab/core/atomic/line.pxd
+++ b/cherab/core/atomic/line.pxd
@@ -23,5 +23,5 @@ cdef class Line:
 
     cdef readonly:
         Element element
-        int ionisation
+        int charge
         tuple transition

--- a/cherab/core/atomic/line.pyx
+++ b/cherab/core/atomic/line.pyx
@@ -26,7 +26,7 @@ cdef class Line:
     atomic data provider.
 
     :param Element element: The atomic element/isotope to which this emission line belongs.
-    :param int ionisation: The ionisation state of the element/isotope that emits this line.
+    :param int charge: The charge state of the element/isotope that emits this line.
     :param tuple transition: A two element tuple that defines the upper and lower electron
       configuration states of the transition. For hydrogen-like ions it may be enough to
       specify the n-levels with integers (e.g. (3,2)). For all other ions the full spectroscopic
@@ -45,15 +45,15 @@ cdef class Line:
         >>> ciii_465 = Line(carbon, 2, ('2s1 3p1 3P4.0', '2s1 3s1 3S1.0'))
     """
 
-    def __init__(self, Element element, int ionisation, tuple transition):
+    def __init__(self, Element element, int charge, tuple transition):
 
-        if ionisation > element.atomic_number - 1:
-            raise ValueError("Ionisation level cannot be larger than one less than the atomic number.")
+        if charge > element.atomic_number - 1:
+            raise ValueError("Charge state cannot be larger than one less than the atomic number.")
 
-        if ionisation < 0:
-            raise ValueError("Ionisation level cannot be less than zero.")
+        if charge < 0:
+            raise ValueError("Charge state cannot be less than zero.")
 
         self.element = element
-        self.ionisation = ionisation
+        self.charge = charge
         self.transition = transition
 

--- a/cherab/core/atomic/rates.pxd
+++ b/cherab/core/atomic/rates.pxd
@@ -69,7 +69,7 @@ cdef class _RadiatedPower:
 
     cdef:
         readonly Element element
-        readonly int ionisation
+        readonly int charge
 
     cdef double evaluate(self, double electron_density, double electron_temperature) except? -1e999
 
@@ -94,7 +94,7 @@ cdef class FractionalAbundance:
 
     cdef:
         readonly Element element
-        readonly int ionisation
+        readonly int charge
         public str name
 
     cdef double evaluate(self, double electron_density, double electron_temperature) except? -1e999

--- a/cherab/core/atomic/rates.pyx
+++ b/cherab/core/atomic/rates.pyx
@@ -201,10 +201,10 @@ cdef class BeamEmissionPEC(_BeamRate):
 cdef class _RadiatedPower:
     """Base class for radiated powers."""
 
-    def __init__(self, Element element, int ionisation):
+    def __init__(self, Element element, int charge):
 
         self.element = element
-        self.ionisation = ionisation
+        self.charge = charge
 
     def __call__(self, double electron_density, double electron_temperature):
         """
@@ -264,18 +264,18 @@ cdef class FractionalAbundance:
     Rate provider for fractional abundances in thermodynamic equilibrium.
 
     :param Element element: the radiating element
-    :param int ionisation: the integer charge state for this ionisation stage
+    :param int charge: the integer charge state for this ionisation stage
     :param str name: optional label identifying this rate
     """
 
-    def __init__(self, element, ionisation, name=''):
+    def __init__(self, element, charge, name=''):
 
         self.name = name
         self.element = element
 
-        if ionisation < 0:
+        if charge < 0:
             raise ValueError("Charge state must be neutral or positive.")
-        self.ionisation = ionisation
+        self.charge = charge
 
     cdef double evaluate(self, double electron_density, double electron_temperature) except? -1e999:
         """
@@ -299,4 +299,4 @@ cdef class FractionalAbundance:
 
         temp = [10**x for x in np.linspace(np.log10(temp_low), np.log10(temp_high), num=num_points)]
         abundances = [self.evaluate(dens, te) for te in temp]
-        plt.semilogx(temp, abundances, '.-', label='{}{}'.format(self.element.symbol, self.ionisation))
+        plt.semilogx(temp, abundances, '.-', label='{}{}'.format(self.element.symbol, self.charge))

--- a/cherab/core/model/attenuator/singleray.pyx
+++ b/cherab/core/model/attenuator/singleray.pyx
@@ -293,7 +293,7 @@ cdef class SingleRayAttenuator(BeamAttenuator):
 
         self._stopping_data = []
         for species in self._plasma.composition:
-            stopping_coeff = self._atomic_data.beam_stopping_rate(self._beam.element, species.element, species.ionisation)
+            stopping_coeff = self._atomic_data.beam_stopping_rate(self._beam.element, species.element, species.charge)
             self._stopping_data.append((species, stopping_coeff))
 
     def _change(self):

--- a/cherab/core/model/beam/charge_exchange.pyx
+++ b/cherab/core/model/beam/charge_exchange.pyx
@@ -278,7 +278,7 @@ cdef class BeamCXLine(BeamModel):
 
         cdef:
             Element receiver_element, donor_element
-            int receiver_ionisation
+            int receiver_charge
             tuple transition
             Species species
             list rates, population_data
@@ -293,22 +293,22 @@ cdef class BeamCXLine(BeamModel):
             raise RuntimeError("The emission line has not been set.")
 
         receiver_element = self._line.element
-        receiver_ionisation = self._line.ionisation + 1
+        receiver_charge = self._line.charge + 1
         donor_element = self._beam.element
         transition = self._line.transition
 
         # locate target species
         try:
-            self._target_species = self._plasma.composition.get(receiver_element, receiver_ionisation)
+            self._target_species = self._plasma.composition.get(receiver_element, receiver_charge)
         except ValueError:
             raise RuntimeError("The plasma object does not contain the ion species for the specified cx line "
-                               "(element={}, ionisation={}).".format(receiver_element.symbol, receiver_ionisation))
+                               "(element={}, ionisation={}).".format(receiver_element.symbol, receiver_charge))
 
         # obtain wavelength for specified line
-        self._wavelength = self._atomic_data.wavelength(receiver_element, receiver_ionisation - 1, transition)
+        self._wavelength = self._atomic_data.wavelength(receiver_element, receiver_charge - 1, transition)
 
         # obtain cx rates
-        rates = self._atomic_data.beam_cx_pec(donor_element, receiver_element, receiver_ionisation, transition)
+        rates = self._atomic_data.beam_cx_pec(donor_element, receiver_element, receiver_charge, transition)
 
         # obtain beam population coefficients for each rate and assemble data
         # the data is assembled to make access efficient by linking the relevant rates and coefficients together:
@@ -335,7 +335,7 @@ cdef class BeamCXLine(BeamModel):
 
                     # bundle coefficient with its species
                     coeff = self._atomic_data.beam_population_rate(donor_element, rate.donor_metastable,
-                                                                   species.element, species.ionisation)
+                                                                   species.element, species.charge)
                     population_data.append((species, coeff))
 
                 # link each rate with its population data

--- a/cherab/core/model/plasma/impact_excitation.pyx
+++ b/cherab/core/model/plasma/impact_excitation.pyx
@@ -48,7 +48,7 @@ cdef class ExcitationLine(PlasmaModel):
         self._change()
 
     def __repr__(self):
-        return '<ExcitationLine: element={}, ionisation={}, transition={}>'.format(self._line.element.name, self._line.ionisation, self._line.transition)
+        return '<ExcitationLine: element={}, charge={}, transition={}>'.format(self._line.element.name, self._line.charge, self._line.transition)
 
     cpdef Spectrum emission(self, Point3D point, Vector3D direction, Spectrum spectrum):
 
@@ -85,16 +85,16 @@ cdef class ExcitationLine(PlasmaModel):
 
         # locate target species
         try:
-            self._target_species = self._plasma.composition.get(self._line.element, self._line.ionisation)
+            self._target_species = self._plasma.composition.get(self._line.element, self._line.charge)
         except ValueError:
             raise RuntimeError("The plasma object does not contain the ion species for the specified line "
-                               "(element={}, ionisation={}).".format(self._line.element.symbol, self._line.ionisation))
+                               "(element={}, ionisation={}).".format(self._line.element.symbol, self._line.charge))
 
         # obtain rate function
-        self._rates = self._atomic_data.impact_excitation_pec(self._line.element, self._line.ionisation, self._line.transition)
+        self._rates = self._atomic_data.impact_excitation_pec(self._line.element, self._line.charge, self._line.transition)
 
         # identify wavelength
-        self._wavelength = self._atomic_data.wavelength(self._line.element, self._line.ionisation, self._line.transition)
+        self._wavelength = self._atomic_data.wavelength(self._line.element, self._line.charge, self._line.transition)
 
         # instance line shape renderer
         self._lineshape = self._lineshape_class(self._line, self._wavelength, self._target_species, self._plasma,

--- a/cherab/core/model/plasma/recombination.pyx
+++ b/cherab/core/model/plasma/recombination.pyx
@@ -48,7 +48,7 @@ cdef class RecombinationLine(PlasmaModel):
         self._change()
 
     def __repr__(self):
-        return '<RecombinationLine: element={}, ionisation={}, transition={}>'.format(self._line.element.name, self._line.ionisation, self._line.transition)
+        return '<RecombinationLine: element={}, charge={}, transition={}>'.format(self._line.element.name, self._line.charge, self._line.transition)
 
     cpdef Spectrum emission(self, Point3D point, Vector3D direction, Spectrum spectrum):
 
@@ -85,19 +85,19 @@ cdef class RecombinationLine(PlasmaModel):
 
         # locate target species
         # note: the target species receives an electron during recombination so must have
-        # an ionisation +1 relative to the ionisation state required for the emission line
-        receiver_ionisation = self._line.ionisation + 1
+        # a charge +1 relative to the charge state required for the emission line
+        receiver_charge = self._line.charge + 1
         try:
-            self._target_species = self._plasma.composition.get(self._line.element, receiver_ionisation)
+            self._target_species = self._plasma.composition.get(self._line.element, receiver_charge)
         except ValueError:
             raise RuntimeError("The plasma object does not contain the ion species for the specified line "
-                               "(element={}, ionisation={}).".format(self._line.element.symbol, receiver_ionisation))
+                               "(element={}, charge={}).".format(self._line.element.symbol, receiver_charge))
 
         # obtain rate function
-        self._rates = self._atomic_data.recombination_pec(self._line.element, self._line.ionisation, self._line.transition)
+        self._rates = self._atomic_data.recombination_pec(self._line.element, self._line.charge, self._line.transition)
 
         # identify wavelength
-        self._wavelength = self._atomic_data.wavelength(self._line.element, self._line.ionisation, self._line.transition)
+        self._wavelength = self._atomic_data.wavelength(self._line.element, self._line.charge, self._line.transition)
 
         # instance line shape renderer
         self._lineshape = self._lineshape_class(self._line, self._wavelength, self._target_species, self._plasma,

--- a/cherab/core/plasma/node.pxd
+++ b/cherab/core/plasma/node.pxd
@@ -36,7 +36,7 @@ cdef class Composition:
 
     cpdef object add(self, Species species)
 
-    cpdef Species get(self, Element element, int ionisation)
+    cpdef Species get(self, Element element, int charge)
 
     cpdef object clear(self)
 

--- a/cherab/core/species.pxd
+++ b/cherab/core/species.pxd
@@ -24,5 +24,5 @@ cdef class Species:
 
     cdef readonly:
         Element element
-        int ionisation
+        int charge
         DistributionFunction distribution

--- a/cherab/core/species.pyx
+++ b/cherab/core/species.pyx
@@ -28,7 +28,7 @@ cdef class Species:
     A class representing a given plasma species.
 
     A plasma in CHERAB will be composed of 1 or more Species objects. A species
-    can be uniquely identified through its element and ionisation stage.
+    can be uniquely identified through its element and charge state.
 
     When instantiating a Species object a 6D distribution function (3 space, 3 velocity)
     must be defined. The DistributionFunction object provides the base interface for
@@ -36,7 +36,7 @@ cdef class Species:
     (such as a Maxwellian for example) or a fully numerically interpolated 6D function.
 
     :param Element element: The element object of this species.
-    :param int ionisation: The ionisation state of the species.
+    :param int charge: The charge state of the species.
     :param DistributionFunction distribution: A distribution function for this species.
 
     .. code-block:: pycon
@@ -60,25 +60,25 @@ cdef class Species:
        >>>
        >>> # Request some properties from the species' distribution function.
        >>> print(d1_species)
-       <Species: element=deuterium, ionisation=1>
+       <Species: element=deuterium, charge=1>
        >>> d1_species.distribution.density(1, -2.5, 7)
        1e+18
     """
 
-    def __init__(self, Element element, int ionisation, DistributionFunction distribution):
+    def __init__(self, Element element, int charge, DistributionFunction distribution):
 
-        if ionisation > element.atomic_number:
-            raise ValueError("Ionisation level cannot be larger than the atomic number.")
+        if charge > element.atomic_number:
+            raise ValueError("Charge state cannot be larger than the atomic number.")
 
-        if ionisation < 0:
-            raise ValueError("Ionisation level cannot be less than zero.")
+        if charge < 0:
+            raise ValueError("Charge state cannot be less than zero.")
 
         self.element = element
-        self.ionisation = ionisation
+        self.charge = charge
         self.distribution = distribution
 
     def __repr__(self):
-        return '<Species: element={}, ionisation={}>'.format(self.element.name, self.ionisation)
+        return '<Species: element={}, charge={}>'.format(self.element.name, self.charge)
 
 
 # todo: move to a common exception module


### PR DESCRIPTION
context of an ion. This is to prevent a name class between the
ion's charge state and the atomic process of ionisation.
Fixes https://github.com/cherab/openadas/issues/21.