### PR TITLE
Feature/more samplers

### DIFF
--- a/cherab/core/math/__init__.py
+++ b/cherab/core/math/__init__.py
@@ -17,6 +17,10 @@
 # under the Licence.
 
 from .samplers import sample1d, sample2d, sample3d, samplevector2d, samplevector3d
+from .samplers import sample1d_points, sample2d_points, sample3d_points
+from .samplers import sample2d_grid, sample3d_grid
+from .samplers import samplevector2d_points, samplevector3d_points
+from .samplers import samplevector2d_grid, samplevector3d_grid
 from .function import Function1D, Function2D, Function3D, VectorFunction2D, VectorFunction3D
 from .interpolators import Interpolate1DLinear, Interpolate1DCubic
 from .interpolators import Interpolate2DLinear, Interpolate2DCubic

--- a/cherab/core/math/samplers.pxd
+++ b/cherab/core/math/samplers.pxd
@@ -15,13 +15,23 @@
 #
 # See the Licence for the specific language governing permissions and limitations
 # under the Licence.
+cimport numpy as np
 
 cpdef tuple sample1d(object function1d, tuple x_range)
+cpdef np.ndarray sample1d_points(object function1d, object x_points)
 
 cpdef tuple sample2d(object function2d, tuple x_range, tuple y_range)
+cpdef np.ndarray sample2d_points(object function2d, object points)
+cpdef np.ndarray sample2d_grid(object function2d, object x, object y)
 
 cpdef tuple sample3d(object function3d, tuple x_range, tuple y_range, tuple z_range)
+cpdef np.ndarray sample3d_points(object function3d, object points)
+cpdef np.ndarray sample3d_grid(object function3d, object x, object y, object z)
 
 cpdef tuple samplevector2d(object function2d, tuple x_range, tuple y_range)
+cpdef np.ndarray samplevector2d_points(object function2d, object points)
+cpdef np.ndarray samplevector2d_grid(object function2d, object x, object y)
 
 cpdef tuple samplevector3d(object function3d, tuple x_range, tuple y_range, tuple z_range)
+cpdef np.ndarray samplevector3d_points(object function3d, object points)
+cpdef np.ndarray samplevector3d_grid(object function3d, object x, object y, object z)

--- a/cherab/core/math/samplers.pyx
+++ b/cherab/core/math/samplers.pyx
@@ -18,11 +18,12 @@
 # See the Licence for the specific language governing permissions and limitations
 # under the Licence.
 
-from numpy import empty, linspace
+from numpy import asarray, empty, linspace
 from cherab.core.math.function cimport Function1D, Function2D, Function3D, VectorFunction2D, VectorFunction3D
 from cherab.core.math.function cimport autowrap_function1d, autowrap_function2d, autowrap_function3d, autowrap_vectorfunction2d, autowrap_vectorfunction3d
 from raysect.core cimport Vector3D
 cimport cython
+cimport numpy as np
 
 """
 This module provides a set of sampling functions for rapidly generating samples
@@ -71,6 +72,37 @@ cpdef tuple sample1d(object function1d, tuple x_range):
         v_view[i] = f1d.evaluate(x_view[i])
 
     return x, v
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cpdef np.ndarray sample1d_points(object function1d, object x_points):
+    """
+    Sample a 1D function at the specified points
+
+    :param function1d: a Python function or Function1D object
+    :param x_points: an array of points at which to sample the function
+    :return: an array containing the sampled values
+    """
+    cdef:
+        int i, nsamples
+        Function1D f1d
+        double[::1] x_view, v_view
+
+    x_points = asarray(x_points)
+
+    f1d = autowrap_function1d(function1d)
+    nsamples = len(x_points)
+
+    v = empty(nsamples)
+
+    x_view = x_points
+    v_view = v
+
+    for i in range(nsamples):
+        v_view[i] = f1d.evaluate(x_view[i])
+
+    return v
 
 
 @cython.boundscheck(False)

--- a/cherab/core/math/samplers.pyx
+++ b/cherab/core/math/samplers.pyx
@@ -186,8 +186,8 @@ cpdef np.ndarray sample2d_points(object function2d, object points):
         raise ValueError("points should be an Nx2 array of points.")
 
     f2d = autowrap_function2d(function2d)
-    x = ascontiguousarray(points[:, 0])
-    y = ascontiguousarray(points[:, 1])
+    x = ascontiguousarray(points[:, 0], dtype=float)
+    y = ascontiguousarray(points[:, 1], dtype=float)
     nsamples = points.shape[0]
     v = empty(nsamples)
 
@@ -220,8 +220,8 @@ cpdef np.ndarray sample2d_grid(object function2d, object x, object y):
         double[::1] x_view, y_view
         double[:, ::1] v_view
 
-    x = ascontiguousarray(x)
-    y = ascontiguousarray(y)
+    x = ascontiguousarray(x, dtype=float)
+    y = ascontiguousarray(y, dtype=float)
     if x.ndim != 1:
         raise ValueError("x should be a 1D sequence of coordinates")
     if y.ndim != 1:
@@ -339,9 +339,9 @@ cpdef np.ndarray sample3d_points(object function3d, object points):
         raise ValueError("points should be an Nx3 array of points.")
 
     f3d = autowrap_function3d(function3d)
-    x = ascontiguousarray(points[:, 0])
-    y = ascontiguousarray(points[:, 1])
-    z = ascontiguousarray(points[:, 2])
+    x = ascontiguousarray(points[:, 0], dtype=float)
+    y = ascontiguousarray(points[:, 1], dtype=float)
+    z = ascontiguousarray(points[:, 2], dtype=float)
     nsamples = points.shape[0]
     v = empty(nsamples)
 
@@ -376,9 +376,9 @@ cpdef np.ndarray sample3d_grid(object function3d, object x, object y, object z):
         double[::1] x_view, y_view, z_view
         double[:, :, ::1] v_view
 
-    x = ascontiguousarray(x)
-    y = ascontiguousarray(y)
-    z = ascontiguousarray(z)
+    x = ascontiguousarray(x, dtype=float)
+    y = ascontiguousarray(y, dtype=float)
+    z = ascontiguousarray(z, dtype=float)
     if x.ndim != 1:
         raise ValueError("x should be a 1D sequence of coordinates")
     if y.ndim != 1:

--- a/cherab/core/math/samplers.pyx
+++ b/cherab/core/math/samplers.pyx
@@ -471,6 +471,97 @@ cpdef tuple samplevector2d(object function2d, tuple x_range, tuple y_range):
     return x, y, v
 
 
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cpdef np.ndarray samplevector2d_points(object function2d, object points):
+    """
+    Sample a 2D vector function at the specified points.
+
+    :param function2d: a Python function or Function2D object
+    :param points: an Nx2 array of points at which to sample the function
+    :return: a Nx3 array containing the sampled values at each point
+
+    This function is for sampling at an unstructured sequence of points.
+    For sampling over a regular grid, consider samplevector2d or
+    samplevector2d_grid instead.
+    """
+    cdef:
+        int i, j, nsamples
+        VectorFunction2D f2d
+        double[::1] x_view, y_view,
+        double [:, ::1] v_view
+        Vector3D vector
+
+    points = asarray(points)
+    if points.ndim != 2 or points.shape[1] != 2:
+        raise ValueError("points should be an Nx2 array of points.")
+
+    f2d = autowrap_vectorfunction2d(function2d)
+    x = ascontiguousarray(points[:, 0], dtype=float)
+    y = ascontiguousarray(points[:, 1], dtype=float)
+    nsamples = points.shape[0]
+    v = empty((nsamples, 3))
+
+    x_view = x
+    y_view = y
+    v_view = v
+
+    for i in range(nsamples):
+        vector = f2d.evaluate(x_view[i], y_view[i])
+        v_view[i, 0] = vector.x
+        v_view[i, 1] = vector.y
+        v_view[i, 2] = vector.z
+
+    return v
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cpdef np.ndarray samplevector2d_grid(object function2d, object x, object y):
+    """
+    Sample a 2D vector function on a rectilinear grid
+
+    :param function2d: a Python function or Function2D object
+    :param x: the x coordinates of each column in the grid
+    :param y: the y coordinates of each row in the grid
+    :return v: a 3D array containing the sampled values at each grid point
+
+    Note that v[i, j] = f(x[i], y[j])
+    """
+    cdef:
+        int i, j, x_samples, y_samples
+        VectorFunction2D f2d
+        double[::1] x_view, y_view
+        double[:, :, ::1] v_view
+        Vector3D vector
+
+    x = ascontiguousarray(x, dtype=float)
+    y = ascontiguousarray(y, dtype=float)
+    if x.ndim != 1:
+        raise ValueError("x should be a 1D sequence of coordinates")
+    if y.ndim != 1:
+        raise ValueError("y should be a 1D sequence of coordinates")
+
+    f2d = autowrap_vectorfunction2d(function2d)
+
+    x_samples = x.shape[0]
+    y_samples = y.shape[0]
+    v = empty((x_samples, y_samples, 3))
+
+    x_view = x
+    y_view = y
+    v_view = v
+
+    for i in range(x_samples):
+        for j in range(y_samples):
+            vector = f2d.evaluate(x_view[i], y_view[j])
+            v_view[i, j, 0] = vector.x
+            v_view[i, j, 1] = vector.y
+            v_view[i, j, 2] = vector.z
+
+    return v
+
+
 # todo: add test
 @cython.boundscheck(False)
 @cython.wraparound(False)
@@ -548,3 +639,103 @@ cpdef tuple samplevector3d(object function3d, tuple x_range, tuple y_range, tupl
                 v_view[i, j, k, 2] = vector.z
 
     return x, y, z, v
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cpdef np.ndarray samplevector3d_points(object function3d, object points):
+    """
+    Sample a 3D vector function at the specified points.
+
+    :param function3d: a Python function or Function3D object
+    :param points: an Nx3 array of points at which to sample the function
+    :return: an Nx3 array containing the sampled values at each point
+
+    This function is for sampling at an unstructured sequence of points.
+    For sampling over a regular grid, consider samplevector3d or
+    samplevector3d_grid instead.
+    """
+    cdef:
+        int i, j, nsamples
+        VectorFunction3D f3d
+        double[::1] x_view, y_view, z_view,
+        double[:, ::1] v_view
+        Vector3D vector
+
+    points = asarray(points)
+    if points.ndim != 2 or points.shape[1] != 3:
+        raise ValueError("points should be an Nx3 array of points.")
+
+    f3d = autowrap_vectorfunction3d(function3d)
+    x = ascontiguousarray(points[:, 0], dtype=float)
+    y = ascontiguousarray(points[:, 1], dtype=float)
+    z = ascontiguousarray(points[:, 2], dtype=float)
+    nsamples = points.shape[0]
+    v = empty((nsamples, 3))
+
+    x_view = x
+    y_view = y
+    z_view = z
+    v_view = v
+
+    for i in range(nsamples):
+        vector = f3d.evaluate(x_view[i], y_view[i], z_view[i])
+        v_view[i, 0] = vector.x
+        v_view[i, 1] = vector.y
+        v_view[i, 2] = vector.z
+
+    return v
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cpdef np.ndarray samplevector3d_grid(object function3d, object x, object y, object z):
+    """
+    Sample a 3D vector function on a rectilinear grid
+
+    :param function3d: a Python function or Function3D object
+    :param x: the x coordinates of each column in the grid
+    :param y: the y coordinates of each row in the grid
+    :param z: the z coordinates of each plane in the grid
+    :return v: an NxMxkx3 array containing the sampled values at each grid point
+
+    Note that v[i, j, k] = f(x[i], y[j], z[k])
+    """
+    cdef:
+        int i, j, k, x_samples, y_samples, z_samples
+        VectorFunction3D f3d
+        double[::1] x_view, y_view, z_view
+        double[:, :, :, ::1] v_view
+        Vector3D vector
+
+    x = ascontiguousarray(x, dtype=float)
+    y = ascontiguousarray(y, dtype=float)
+    z = ascontiguousarray(z, dtype=float)
+    if x.ndim != 1:
+        raise ValueError("x should be a 1D sequence of coordinates")
+    if y.ndim != 1:
+        raise ValueError("y should be a 1D sequence of coordinates")
+    if z.ndim != 1:
+        raise ValueError("z should be a 1D sequence of coordinates")
+
+    f3d = autowrap_vectorfunction3d(function3d)
+
+    x_samples = x.shape[0]
+    y_samples = y.shape[0]
+    z_samples = z.shape[0]
+    v = empty((x_samples, y_samples, z_samples, 3))
+
+    x_view = x
+    y_view = y
+    z_view = z
+    v_view = v
+
+    for i in range(x_samples):
+        for j in range(y_samples):
+            for k in range(z_samples):
+                vector = f3d.evaluate(x_view[i], y_view[j], z_view[k])
+                v_view[i, j, k, 0] = vector.x
+                v_view[i, j, k, 1] = vector.y
+                v_view[i, j, k, 2] = vector.z
+
+    return v

--- a/cherab/core/math/tests/test_samplers.py
+++ b/cherab/core/math/tests/test_samplers.py
@@ -22,6 +22,9 @@ from cherab.core.math.samplers import sample1d, sample2d, sample3d
 from cherab.core.math.samplers import sample1d_points
 from cherab.core.math.samplers import sample2d_points, sample2d_grid
 from cherab.core.math.samplers import sample3d_points, sample3d_grid
+from cherab.core.math.samplers import samplevector2d_points, samplevector2d_grid
+from cherab.core.math.samplers import samplevector3d_points, samplevector3d_grid
+from raysect.core import Vector3D
 
 
 def fn1d(x):
@@ -46,6 +49,27 @@ def fn3d(x, y, z):
     """
 
     return x * x + 0.5 * y - z
+
+
+def vfn1d(x):
+    """
+    Python 1D vector test function
+    """
+    return Vector3D(fn1d(x), 2 * fn1d(x), -fn1d(x))
+
+
+def vfn2d(x, y):
+    """
+    Python 2D vector test function
+    """
+    return Vector3D(fn2d(x, y), 2 * fn2d(x, y), -fn2d(x, y))
+
+
+def vfn3d(x, y, z):
+    """
+    Python 3D vector test function
+    """
+    return Vector3D(fn3d(x, y, z), 2 * fn3d(x, y, z), -fn3d(x, y, z))
 
 
 class TestSampler1D(unittest.TestCase):
@@ -117,6 +141,7 @@ class TestSample1DPoints(unittest.TestCase):
 
         for i in range(3):
             self.assertEqual(ts[i], rs[i], "Sample point [{}] is incorrect.".format(i))
+
 
 class TestSampler2D(unittest.TestCase):
 
@@ -368,6 +393,7 @@ class TestSampler3D(unittest.TestCase):
 
                     self.assertEqual(ts[i][j][k], rs[i][j][k], "Sample point [{}, {}, {}] is incorrect.".format(i, j, k))
 
+
 class TestSample3DPoints(unittest.TestCase):
 
     def test_sample3d_points_invalid_points_type(self):
@@ -434,3 +460,146 @@ class TestSample3DGrid(unittest.TestCase):
             for j in range(3):
                 for k in range(3):
                     self.assertEqual(ts[i, j, k], rs[i, j, k], "Sample point [{}] is incorrect.".format(i))
+
+
+class TestSampleVector2DPoints(unittest.TestCase):
+
+    def test_samplevector2d_points_invalid_points_type(self):
+         # invalid type
+        with self.assertRaises(ValueError, msg="Type error was not raised when a string was (invalidly) supplied for the range."):
+            samplevector2d_points(vfn2d, "blah")
+
+    def test_samplevector2d_points_invalid_points_shape(self):
+        with self.assertRaises(ValueError, msg="Type error was not raised when the points array was the wrong shape."):
+            samplevector2d_points(vfn2d, empty((3, 3)))
+
+    def test_samplevector2d_points_invalid_function_called(self):
+        # invalid function type
+        with self.assertRaises(TypeError, msg="Type error was not raised when a string was (invalidly) supplied for the function."):
+            samplevector2d_points("blah", empty(3, 2))
+
+    def test_samplevector2d_points_sample(self):
+        rx = [1.0, 1.5, 2.0]
+        ry = [2.0, 2.5, 3.0]
+        rpoints = empty((3, 2))
+        rpoints[:, 0] = rx
+        rpoints[:, 1] = ry
+        rs = empty((3, 3))
+        for i in range(3):
+            rs[i, 0] = rx[i] * rx[i] + 0.5 * ry[i]
+            rs[i, 1] = 2 * rs[i, 0]
+            rs[i, 2] = -rs[i, 0]
+
+
+        ts = samplevector2d_points(vfn2d, rpoints)
+
+        for i in range(3):
+            for j in range(3):
+                self.assertEqual(ts[i, j], rs[i, j], "Sample point [{}] is incorrect.".format((i, j)))
+
+
+class TestSampleVector2DGrid(unittest.TestCase):
+
+    def test_samplevector2d_grid_invalid_coords_type(self):
+        with self.assertRaises(ValueError, msg="Value error was not raised when the coordinate arrays were the wrong type"):
+            samplevector2d_grid(vfn2d, "blah", 10)
+
+    def test_samplevector2d_grid_invalid_coords_shape(self):
+        with self.assertRaises(ValueError, msg="Value error was not raised when the coordinate arrays were the wrong shape"):
+            samplevector2d_grid(vfn2d, empty((10, 2)), empty((2, 10)))
+
+    def test_samplevector2d_grid_invalid_function_called(self):
+        # invalid function type
+        with self.assertRaises(TypeError, msg="Type error was not raised when a string was (invalidly) supplied for the function."):
+            samplevector2d_grid("blah", empty(3), empty(2))
+
+    def test_samplevector2d_grid_sample(self):
+        rx = [1.0, 1.5, 2.0]
+        ry = [2.0, 2.5, 3.0]
+        rs = empty((3, 3, 3))
+        for i in range(3):
+            for j in range(3):
+                rs[i, j, 0] = rx[i] * rx[i] + 0.5 * ry[j]
+                rs[i, j, 1] = 2 * rs[i, j, 0]
+                rs[i, j, 2] = -rs[i, j, 0]
+
+        ts = samplevector2d_grid(vfn2d, rx, ry)
+
+        for i in range(3):
+            for j in range(3):
+                for k in range(3):
+                    self.assertEqual(ts[i, j, k], rs[i, j, k], "Sample point [{}] is incorrect.".format((i, j, k)))
+
+
+class TestSamplevector3DPoints(unittest.TestCase):
+
+    def test_samplevector3d_points_invalid_points_type(self):
+         # invalid type
+        with self.assertRaises(ValueError, msg="Type error was not raised when a string was (invalidly) supplied for the range."):
+            samplevector3d_points(vfn3d, "blah")
+
+    def test_samplevector3d_points_invalid_points_shape(self):
+        with self.assertRaises(ValueError, msg="Type error was not raised when the points array was the wrong shape."):
+            samplevector3d_points(vfn3d, empty((3, 2)))
+
+    def test_samplevector3d_points_invalid_function_called(self):
+        # invalid function type
+        with self.assertRaises(TypeError, msg="Type error was not raised when a string was (invalidly) supplied for the function."):
+            samplevector3d_points("blah", empty(3, 2))
+
+    def test_samplevector3d_points_sample(self):
+        rx = [1.0, 1.5, 2.0]
+        ry = [2.0, 2.5, 3.0]
+        rz = [3.0, 3.5, 4.0]
+        rpoints = empty((3, 3))
+        rpoints[:, 0] = rx
+        rpoints[:, 1] = ry
+        rpoints[:, 2] = rz
+        rs = empty((3, 3))
+        for i in range(3):
+            rs[i, 0] = rx[i] * rx[i] + 0.5 * ry[i] - rz[i]
+            rs[i, 1] = 2 * rs[i, 0]
+            rs[i, 2] = -rs[i, 0]
+
+
+        ts = samplevector3d_points(vfn3d, rpoints)
+
+        for i in range(3):
+            for j in range(3):
+                self.assertEqual(ts[i, j], rs[i, j], "Sample point [{}] is incorrect.".format((i, j)))
+
+
+class TestSamplevector3DGrid(unittest.TestCase):
+
+    def test_samplevector3d_grid_invalid_coords_type(self):
+        with self.assertRaises(ValueError, msg="Value error was not raised when the coordinate arrays were the wrong type"):
+            samplevector3d_grid(vfn3d, "blah", 10, {})
+
+    def test_samplevector3d_grid_invalid_coords_shape(self):
+        with self.assertRaises(ValueError, msg="Value error was not raised when the coordinate arrays were the wrong shape"):
+            samplevector3d_grid(vfn3d, empty((10, 2)), empty((2, 10)), empty((10)))
+
+    def test_samplevector3d_grid_invalid_function_called(self):
+        # invalid function type
+        with self.assertRaises(TypeError, msg="Type error was not raised when a string was (invalidly) supplied for the function."):
+            samplevector3d_grid("blah", empty(3), empty(2), empty(5))
+
+    def test_samplevector3d_grid_sample(self):
+        rx = [1.0, 1.5, 2.0]
+        ry = [2.0, 2.5, 3.0]
+        rz = [3.0, 3.5, 4.0]
+        rs = empty((3, 3, 3, 3))
+        for i in range(3):
+            for j in range(3):
+                for k in range(3):
+                    rs[i, j, k, 0] = rx[i] * rx[i] + 0.5 * ry[j] - rz[k]
+                    rs[i, j, k, 1] = 2 * rs[i, j, k, 0]
+                    rs[i, j, k, 2] = -rs[i, j, k, 0]
+
+        ts = samplevector3d_grid(vfn3d, rx, ry, rz)
+
+        for i in range(3):
+            for j in range(3):
+                for k in range(3):
+                    for h in range(3):
+                        self.assertEqual(ts[i, j, k, h], rs[i, j, k, h], "Sample point [{}] is incorrect.".format((i, j, k, h)))

--- a/cherab/core/math/tests/test_samplers.py
+++ b/cherab/core/math/tests/test_samplers.py
@@ -19,6 +19,7 @@
 import unittest
 from numpy import empty
 from cherab.core.math.samplers import sample1d, sample2d, sample3d
+from cherab.core.math.samplers import sample1d_points
 
 
 def fn1d(x):
@@ -94,6 +95,26 @@ class TestSampler1D(unittest.TestCase):
             self.assertEqual(tx[i], rx[i], "X points [{}] is incorrect.".format(i))
             self.assertEqual(ts[i], rs[i], "Sample point [{}] is incorrect.".format(i))
 
+
+class TestSample1DPoints(unittest.TestCase):
+
+    def test_sample1d_points_invalid_range_type(self):
+         # invalid type
+        with self.assertRaises(TypeError, msg="Type error was not raised when a string was (invalidly) supplied for the range."):
+            sample1d_points(fn1d, "blah")
+
+    def test_sample1d_invalid_function_called(self):
+        # invalid function type
+        with self.assertRaises(TypeError, msg="Type error was not raised when a string was (invalidly) supplied for the function."):
+            sample1d("blah", (1, 2, 3))
+
+    def test_sample1d_sample(self):
+        rx = [1.0, 1.5, 2.0]
+        rs = [1.0, 2.25, 4.0]
+        ts = sample1d_points(fn1d, rx)
+
+        for i in range(3):
+            self.assertEqual(ts[i], rs[i], "Sample point [{}] is incorrect.".format(i))
 
 class TestSampler2D(unittest.TestCase):
 

--- a/cherab/core/math/tests/test_samplers.py
+++ b/cherab/core/math/tests/test_samplers.py
@@ -20,6 +20,7 @@ import unittest
 from numpy import empty
 from cherab.core.math.samplers import sample1d, sample2d, sample3d
 from cherab.core.math.samplers import sample1d_points
+from cherab.core.math.samplers import sample2d_points, sample2d_grid
 
 
 def fn1d(x):
@@ -98,15 +99,15 @@ class TestSampler1D(unittest.TestCase):
 
 class TestSample1DPoints(unittest.TestCase):
 
-    def test_sample1d_points_invalid_range_type(self):
+    def test_sample1d_points_invalid_points_type(self):
          # invalid type
-        with self.assertRaises(TypeError, msg="Type error was not raised when a string was (invalidly) supplied for the range."):
+        with self.assertRaises(ValueError, msg="Value error was not raised when a string was (invalidly) supplied for the range."):
             sample1d_points(fn1d, "blah")
 
     def test_sample1d_invalid_function_called(self):
         # invalid function type
         with self.assertRaises(TypeError, msg="Type error was not raised when a string was (invalidly) supplied for the function."):
-            sample1d("blah", (1, 2, 3))
+            sample1d_points("blah", (1, 2, 3))
 
     def test_sample1d_sample(self):
         rx = [1.0, 1.5, 2.0]
@@ -196,6 +197,68 @@ class TestSampler2D(unittest.TestCase):
 
                 self.assertEqual(ts[i][j], rs[i][j], "Sample point [{}, {}] is incorrect.".format(i, j))
 
+
+class TestSample2DPoints(unittest.TestCase):
+
+    def test_sample2d_points_invalid_points_type(self):
+         # invalid type
+        with self.assertRaises(ValueError, msg="Type error was not raised when a string was (invalidly) supplied for the range."):
+            sample2d_points(fn2d, "blah")
+
+    def test_sample2d_points_invalid_points_shape(self):
+        with self.assertRaises(ValueError, msg="Type error was not raised when the points array was the wrong shape."):
+            sample2d_points(fn2d, empty((3, 3)))
+
+    def test_sample2d_points_invalid_function_called(self):
+        # invalid function type
+        with self.assertRaises(TypeError, msg="Type error was not raised when a string was (invalidly) supplied for the function."):
+            sample2d_points("blah", empty(3, 2))
+
+    def test_sample2d_points_sample(self):
+        rx = [1.0, 1.5, 2.0]
+        ry = [2.0, 2.5, 3.0]
+        rpoints = empty((3, 2))
+        rpoints[:, 0] = rx
+        rpoints[:, 1] = ry
+        rs = empty(3)
+        for i in range(3):
+            rs[i] = rx[i] * rx[i] + 0.5 * ry[i]
+
+
+        ts = sample2d_points(fn2d, rpoints)
+
+        for i in range(3):
+            self.assertEqual(ts[i], rs[i], "Sample point [{}] is incorrect.".format(i))
+
+
+class TestSample2DGrid(unittest.TestCase):
+
+    def test_sample2d_grid_invalid_coords_type(self):
+        with self.assertRaises(ValueError, msg="Value error was not raised when the coordinate arrays were the wrong type"):
+            sample2d_grid(fn2d, "blah", 10)
+
+    def test_sample2d_grid_invalid_coords_shape(self):
+        with self.assertRaises(ValueError, msg="Value error was not raised when the coordinate arrays were the wrong shape"):
+            sample2d_grid(fn2d, empty((10, 2)), empty((2, 10)))
+
+    def test_sample2d_grid_invalid_function_called(self):
+        # invalid function type
+        with self.assertRaises(TypeError, msg="Type error was not raised when a string was (invalidly) supplied for the function."):
+            sample2d_grid("blah", empty(3), empty(2))
+
+    def test_sample2d_grid_sample(self):
+        rx = [1.0, 1.5, 2.0]
+        ry = [2.0, 2.5, 3.0]
+        rs = empty((3, 3))
+        for i in range(3):
+            for j in range(3):
+                rs[i, j] = rx[i] * rx[i] + 0.5 * ry[j]
+
+        ts = sample2d_grid(fn2d, rx, ry)
+
+        for i in range(3):
+            for j in range(3):
+                self.assertEqual(ts[i, j], rs[i, j], "Sample point [{}] is incorrect.".format(i))
 
 class TestSampler3D(unittest.TestCase):
 

--- a/cherab/core/math/tests/test_samplers.py
+++ b/cherab/core/math/tests/test_samplers.py
@@ -21,6 +21,7 @@ from numpy import empty
 from cherab.core.math.samplers import sample1d, sample2d, sample3d
 from cherab.core.math.samplers import sample1d_points
 from cherab.core.math.samplers import sample2d_points, sample2d_grid
+from cherab.core.math.samplers import sample3d_points, sample3d_grid
 
 
 def fn1d(x):
@@ -260,6 +261,7 @@ class TestSample2DGrid(unittest.TestCase):
             for j in range(3):
                 self.assertEqual(ts[i, j], rs[i, j], "Sample point [{}] is incorrect.".format(i))
 
+
 class TestSampler3D(unittest.TestCase):
 
     def test_sample3d_invalid_range_type(self):
@@ -365,3 +367,70 @@ class TestSampler3D(unittest.TestCase):
                 for k in range(3):
 
                     self.assertEqual(ts[i][j][k], rs[i][j][k], "Sample point [{}, {}, {}] is incorrect.".format(i, j, k))
+
+class TestSample3DPoints(unittest.TestCase):
+
+    def test_sample3d_points_invalid_points_type(self):
+         # invalid type
+        with self.assertRaises(ValueError, msg="Type error was not raised when a string was (invalidly) supplied for the range."):
+            sample3d_points(fn3d, "blah")
+
+    def test_sample3d_points_invalid_points_shape(self):
+        with self.assertRaises(ValueError, msg="Type error was not raised when the points array was the wrong shape."):
+            sample3d_points(fn3d, empty((3, 2)))
+
+    def test_sample3d_points_invalid_function_called(self):
+        # invalid function type
+        with self.assertRaises(TypeError, msg="Type error was not raised when a string was (invalidly) supplied for the function."):
+            sample3d_points("blah", empty(3, 2))
+
+    def test_sample3d_points_sample(self):
+        rx = [1.0, 1.5, 2.0]
+        ry = [2.0, 2.5, 3.0]
+        rz = [3.0, 3.5, 4.0]
+        rpoints = empty((3, 3))
+        rpoints[:, 0] = rx
+        rpoints[:, 1] = ry
+        rpoints[:, 2] = rz
+        rs = empty(3)
+        for i in range(3):
+            rs[i] = rx[i] * rx[i] + 0.5 * ry[i] - rz[i]
+
+
+        ts = sample3d_points(fn3d, rpoints)
+
+        for i in range(3):
+            self.assertEqual(ts[i], rs[i], "Sample point [{}] is incorrect.".format(i))
+
+
+class TestSample3DGrid(unittest.TestCase):
+
+    def test_sample3d_grid_invalid_coords_type(self):
+        with self.assertRaises(ValueError, msg="Value error was not raised when the coordinate arrays were the wrong type"):
+            sample3d_grid(fn3d, "blah", 10, {})
+
+    def test_sample3d_grid_invalid_coords_shape(self):
+        with self.assertRaises(ValueError, msg="Value error was not raised when the coordinate arrays were the wrong shape"):
+            sample3d_grid(fn3d, empty((10, 2)), empty((2, 10)), empty((10)))
+
+    def test_sample3d_grid_invalid_function_called(self):
+        # invalid function type
+        with self.assertRaises(TypeError, msg="Type error was not raised when a string was (invalidly) supplied for the function."):
+            sample3d_grid("blah", empty(3), empty(2), empty(5))
+
+    def test_sample3d_grid_sample(self):
+        rx = [1.0, 1.5, 2.0]
+        ry = [2.0, 2.5, 3.0]
+        rz = [3.0, 3.5, 4.0]
+        rs = empty((3, 3, 3))
+        for i in range(3):
+            for j in range(3):
+                for k in range(3):
+                    rs[i, j, k] = rx[i] * rx[i] + 0.5 * ry[j] - rz[k]
+
+        ts = sample3d_grid(fn3d, rx, ry, rz)
+
+        for i in range(3):
+            for j in range(3):
+                for k in range(3):
+                    self.assertEqual(ts[i, j, k], rs[i, j, k], "Sample point [{}] is incorrect.".format(i))


### PR DESCRIPTION
Adds several new sampling functions. In 1D, 2D and 3D a function can now be sampled at a list of points, passed in as an N, Nx2 or Nx3 array respectively. Also, 2D and 3D functions can be sampled on a grid, where the coordinates of the rows and columns are explicitly provided, rather than derived from input ranges. The same functionality is available for functions which return a scalar or a Vector3D. Also, tests for all new functions have been added, based on the previous set of unit tests for the samplers.