### PR TITLE
Feature/admt

### DIFF
--- a/cherab/tools/inversions/__init__.py
+++ b/cherab/tools/inversions/__init__.py
@@ -22,3 +22,4 @@ from .nnls import invert_regularised_nnls
 from .lstsq import invert_regularised_lstsq
 from .svd import invert_svd
 from .voxels import Voxel, AxisymmetricVoxel, VoxelCollection, ToroidalVoxelGrid, UnityVoxelEmitter
+from .admt_utils import generate_derivative_operators, calculate_admt

--- a/cherab/tools/inversions/admt_utils.py
+++ b/cherab/tools/inversions/admt_utils.py
@@ -304,12 +304,13 @@ def calculate_admt(voxel_radii, derivative_operators, psi_at_voxels, dx, dy, ani
     )
     dnorm_term_cy = -2 / normalisation * (
         (Dperp * dpsidy**2 + Dpar * dpsidx**2) * (dpsidx * dpsidxdy + dpsidy * dpsidyy)
-        + (Dperp - Dpar) * (dpsidy * dpsidy) * (dpsidx * dpsidxx + dpsidy * dpsidxdy)
+        + (Dperp - Dpar) * (dpsidx * dpsidy) * (dpsidx * dpsidxx + dpsidy * dpsidxdy)
     )
     toroidal_term_cx = cxx / voxel_radii * normalisation
     toroidal_term_cy = cxy / voxel_radii * normalisation
     cx = (
-        2 * Dperp * dpsidxx * dpsidx + 2 * Dpar * dpsidxdy * dpsidy
+        2 * Dperp * dpsidxx * dpsidx
+        + 2 * Dpar * dpsidxdy * dpsidy
         + (Dperp - Dpar) * (dpsidxdy * dpsidy + dpsidyy * dpsidx)
         + ddiff_term_cx + dnorm_term_cx + toroidal_term_cx
     ) / normalisation

--- a/cherab/tools/inversions/admt_utils.py
+++ b/cherab/tools/inversions/admt_utils.py
@@ -58,10 +58,11 @@ def generate_derivative_operators(voxel_coords, grid_index_1d_to_2d_map,
     # order with each successive voxel in a column below the previous one.
     # We should try to support voxel grids of different voxel sizes too.
     cell_sizes = np.diff(cell_centres, axis=0)
-    dx = cell_sizes[0, :]
-    dy = cell_sizes[1, :]
+    dx = cell_sizes[:, 0]
+    dy = cell_sizes[:, 1]
+    # dx and dy are distances in Ingesson's report, so should be positive
     dx = np.min(abs(dx[dx != 0])).item()
-    dy = -np.min(abs(dy[dy != 0])).item()
+    dy = np.min(abs(dy[dy != 0])).item()
 
     # Note that iy increases as y decreases (cells go from top to bottom),
     # which is the same as Ingesson's notation in equations 37-41

--- a/cherab/tools/inversions/admt_utils.py
+++ b/cherab/tools/inversions/admt_utils.py
@@ -7,16 +7,17 @@ for details.
 """
 __author__ = "Jack Lovell, Oak Ridge National Laboratory"
 
+from collections import Mapping
 import numpy as np
 
 
-def generate_derivative_operators(voxel_coords, grid_index_1d_to_2d_map,
+def generate_derivative_operators(voxel_vertices, grid_index_1d_to_2d_map,
                                   grid_index_2d_to_1d_map):
     r"""
     Generate the first and second derivative operators for a regular grid.
 
-    :param ndarray voxel_coords: an Nx2 array of coordinates of the
-    centre of each voxel, (R, Z)
+    :param ndarray voxel_vertices: an Nx4x2 array of coordinates of the
+    vertices of each voxel, (R, Z)
     :param dict grid_1d_to_2d_map: a mapping from the 1D array of
     voxels in the grid to a 2D array of voxels if they were arranged
     spatially.
@@ -44,8 +45,17 @@ def generate_derivative_operators(voxel_coords, grid_index_1d_to_2d_map,
 
     etc.
     """
-    num_cells = len(voxel_coords)
-    cell_centres = np.mean(voxel_coords, axis=1)
+    # Input argument validation: assume rectilinear voxels
+    voxel_vertices = np.asarray(voxel_vertices)
+    if voxel_vertices.ndim != 3 or voxel_vertices.shape[-2] != 4 or voxel_vertices.shape[-1] != 2:
+        raise TypeError("voxel_vertices must be an NxMx2 array of vertices")
+    if not isinstance(grid_index_1d_to_2d_map, Mapping):
+        raise TypeError("grid_index_1d_to_2d_map should be dict-like")
+    if not isinstance(grid_index_2d_to_1d_map, Mapping):
+        raise TypeError("grid_index_2d_to_1d_map should be dict-like")
+
+    num_cells = voxel_vertices.shape[0]
+    cell_centres = np.mean(voxel_vertices, axis=1)
     # Individual derivative operators
     Dx = np.zeros((num_cells, num_cells))
     Dy = np.zeros((num_cells, num_cells))

--- a/cherab/tools/inversions/admt_utils.py
+++ b/cherab/tools/inversions/admt_utils.py
@@ -5,10 +5,11 @@ This is based on work by L. C. Ingesson: see JET-R(99)08 available at
 http://www.euro-fusionscipub.org/wp-content/uploads/2014/11/JETR99008.pdf
 for details.
 """
+import numpy as np
 
 
-def generate_derivative_operators(voxel_coords, grid_1d_to_2d_map,
-                                  grid_2d_to_1d_map):
+def generate_derivative_operators(voxel_coords, grid_index_1d_to_2d_map,
+                                  grid_index_2d_to_1d_map):
     r"""
     Generate the first and second derivative operators for a regular grid.
 
@@ -20,14 +21,14 @@ def generate_derivative_operators(voxel_coords, grid_1d_to_2d_map,
     :param dict grid_2d_to_1d_map: the inverse mapping from a 2D
     spatially-arranged array of voxels to the 1D array.
 
-    :return tuple operators: a named tuple containing the derivative
+    :return dict operators: a dictionary containing the derivative
     operators: Dij for i, y ∊ (x, y) and Di for i ∊ (x, y).
 
     This function assumes that all voxels are rectilinear, with their
     axes aligned to the coordinate axes. If this is not the case, the
     results will be nonsense.
 
-    The return tuple contains all the first and second derivative
+    The return dict contains all the first and second derivative
     operators:
 
     .. math::
@@ -36,7 +37,180 @@ def generate_derivative_operators(voxel_coords, grid_1d_to_2d_map,
 
     etc.
     """
-    return
+    num_cells = len(voxel_coords)
+    cell_centres = np.mean(voxel_coords, axis=1)
+    # Individual derivative operators
+    Dx = np.zeros((num_cells, num_cells))
+    Dy = np.zeros((num_cells, num_cells))
+    Dxx = np.zeros((num_cells, num_cells))
+    Dxy = np.zeros((num_cells, num_cells))
+    Dyy = np.zeros((num_cells, num_cells))
+    # TODO: for now, we assume all voxels have rectangular cross sections
+    # which are approximately identical. As per Ingesson's notation, we
+    # assume voxels are ordered from top left to bottom right, in column-major
+    # order with each successive voxel in a column below the previous one.
+    # We should try to support voxel grids of different voxel sizes too.
+    dx, dy = np.diff(cell_centres[:2], axis=0).flatten()
+    dx = np.min(abs(dx[dx != 0])).item()
+    dy = -np.min(abs(dy[dy != 0])).item()
+
+    # Note that iy increases as y decreases (cells go from top to bottom),
+    # which is the same as Ingesson's notation in equations 37-41
+    # Use the second version of the second derivative boundary formulae, so
+    # that we only need to consider nearest neighbours
+    for ith_cell in range(num_cells):
+        at_top, at_bottom, at_left, at_right = False, False, False, False
+        n_left, n_right, n_below, n_above = np.nan, np.nan, np.nan, np.nan
+        n_above_left, n_above_right, n_below_left, n_below_right = np.nan, np.nan, np.nan, np.nan
+        # get the 2D mesh coordinates of this cell
+        ix, iy = grid_index_1d_to_2d_map[ith_cell]
+
+        try:
+            n_left = grid_index_2d_to_1d_map[ix - 1, iy]  # neighbour 1, left of n0
+        except KeyError:
+            at_left = True
+        else:
+            Dx[ith_cell, n_left] = -1 / 2
+            Dxx[ith_cell, n_left] = 1
+
+        try:
+            n_below_left = grid_index_2d_to_1d_map[ix - 1, iy + 1]  # neighbour 2, below left of n0
+        except KeyError:
+            pass
+            # KeyError does not necessarily mean bottom AND left
+        else:
+            Dxy[ith_cell, n_below_left] = 1 / 4
+
+        try:
+            n_below = grid_index_2d_to_1d_map[ix, iy + 1]  # neighbour 3, below n0
+        except KeyError:
+            at_bottom = True
+        else:
+            Dy[ith_cell, n_below] = -1 / 2
+            Dyy[ith_cell, n_below] = 1
+
+        try:
+            n_below_right = grid_index_2d_to_1d_map[ix + 1, iy + 1]  # neighbour 4, below right of n0
+        except KeyError:
+            pass
+        else:
+            Dxy[ith_cell, n_below_right] = -1 / 4
+
+        try:
+            n_right = grid_index_2d_to_1d_map[ix + 1, iy]  # neighbour 5, right of n0
+        except KeyError:
+            at_right = True
+        else:
+            Dx[ith_cell, n_right] = 1 / 2
+            Dxx[ith_cell, n_right] = 1
+
+        try:
+            n_above_right = grid_index_2d_to_1d_map[ix + 1, iy - 1]  # neighbour 6, above right of n0
+        except KeyError:
+            pass
+        else:
+            Dxy[ith_cell, n_above_right] = 1 / 4
+
+        try:
+            n_above = grid_index_2d_to_1d_map[ix, iy - 1]  # neighbour 7, above n0
+        except KeyError:
+            at_top = True
+        else:
+            Dy[ith_cell, n_above] = 1 / 2
+            Dyy[ith_cell, n_above] = 1
+
+        try:
+            n_above_left = grid_index_2d_to_1d_map[ix - 1, iy - 1]  # neighbour 8, above left of n0
+        except KeyError:
+            pass
+        else:
+            Dxy[ith_cell, n_above_left] = -1 / 4
+
+        top_left = at_top and at_left
+        top_right = at_top and at_right
+        bottom_left = at_bottom and at_left
+        bottom_right = at_bottom and at_right
+
+        Dxx[ith_cell, ith_cell] = -2
+        Dyy[ith_cell, ith_cell] = -2
+
+        if at_left:
+            Dx[ith_cell, ith_cell] = -1
+            Dx[ith_cell, n_right] = 1
+            Dxx[ith_cell, ith_cell] = -1
+            Dxx[ith_cell, n_right] = 1
+            if not (top_left or bottom_left):
+                Dxy[ith_cell, n_above_right] = 1 / 2
+                Dxy[ith_cell, n_below] = 1 / 2
+                Dxy[ith_cell, n_above] = -1 / 2
+                Dxy[ith_cell, n_below_right] = -1 / 2
+
+        if at_right:
+            Dx[ith_cell, n_left] = -1
+            Dx[ith_cell, ith_cell] = 1
+            Dxx[ith_cell, n_left] = -1
+            Dxx[ith_cell, ith_cell] = 1
+            if not (top_right or bottom_right):
+                Dxy[ith_cell, n_above] = 1 / 2
+                Dxy[ith_cell, n_below_left] = 1 / 2
+                Dxy[ith_cell, n_above_left] = -1 / 2
+                Dxy[ith_cell, n_below] = -1 / 2
+
+        if at_top:
+            Dy[ith_cell, n_below] = -1
+            Dy[ith_cell, ith_cell] = 1
+            Dyy[ith_cell, n_below] = -1
+            Dyy[ith_cell, ith_cell] = 1
+            if not (top_left or top_right):
+                Dxy[ith_cell, n_right] = 1 / 2
+                Dxy[ith_cell, n_below_left] = 1 / 2
+                Dxy[ith_cell, n_left] = -1 / 2
+                Dxy[ith_cell, n_below_right] = -1 / 2
+
+        if at_bottom:
+            Dy[ith_cell, n_above] = 1
+            Dy[ith_cell, ith_cell] = -1
+            Dyy[ith_cell, n_above] = 1
+            Dyy[ith_cell, ith_cell] = -1
+            if not (bottom_left or bottom_right):
+                Dxy[ith_cell, n_above_right] = 1 / 2
+                Dxy[ith_cell, n_left] = 1 / 2
+                Dxy[ith_cell, n_above_left] = -1 / 2
+                Dxy[ith_cell, n_right] = -1 / 2
+
+        if top_left:
+            Dxy[ith_cell, n_below] = 1
+            Dxy[ith_cell, n_right] = 1
+            Dxy[ith_cell, ith_cell] = -1
+            Dxy[ith_cell, n_below_right] = -1
+
+        if top_right:
+            Dxy[ith_cell, ith_cell] = 1
+            Dxy[ith_cell, n_below_left] = 1
+            Dxy[ith_cell, n_left] = -1
+            Dxy[ith_cell, n_below] = -1
+
+        if bottom_left:
+            Dxy[ith_cell, n_above_right] = 1
+            Dxy[ith_cell, ith_cell] = 1
+            Dxy[ith_cell, n_above] = -1
+            Dxy[ith_cell, n_right] = -1
+
+        if bottom_right:
+            Dxy[ith_cell, n_above] = 1
+            Dxy[ith_cell, n_left] = 1
+            Dxy[ith_cell, ith_cell] = -1
+            Dxy[ith_cell, n_above_left] = -1
+
+    Dx = Dx / dx
+    Dy = Dy / dy
+    Dxx = Dxx / dx**2
+    Dyy = Dyy / dy**2
+    Dxy = Dxy / (dx * dy)
+
+    # Package all operators up into a dictionary
+    operators = dict(Dx=Dx, Dy=Dy, Dxx=Dxx, Dyy=Dyy, Dxy=Dxy)
+    return operators
 
 
 def calculate_admt(voxel_radii, derivative_operators, psi_at_voxels, anisotropy=10):

--- a/cherab/tools/inversions/admt_utils.py
+++ b/cherab/tools/inversions/admt_utils.py
@@ -44,6 +44,12 @@ def generate_derivative_operators(voxel_vertices, grid_index_1d_to_2d_map,
         D_{xy} \equiv \frac{\partial^2}{\partial x \partial y}
 
     etc.
+
+    Note that the standard 2D laplacian (for isotropic regularisation)
+    can be trivially calculated as L = Dxx * dx + Dyy * dy, where dx and
+    dy are the voxel width and height respectively. This expression does
+    not however produce the 2D laplacian derived from the N-dimensional
+    case.
     """
     # Input argument validation: assume rectilinear voxels
     voxel_vertices = np.asarray(voxel_vertices)

--- a/cherab/tools/inversions/admt_utils.py
+++ b/cherab/tools/inversions/admt_utils.py
@@ -50,7 +50,9 @@ def generate_derivative_operators(voxel_coords, grid_index_1d_to_2d_map,
     # assume voxels are ordered from top left to bottom right, in column-major
     # order with each successive voxel in a column below the previous one.
     # We should try to support voxel grids of different voxel sizes too.
-    dx, dy = np.diff(cell_centres[:2], axis=0).flatten()
+    cell_sizes = np.diff(cell_centres, axis=0)
+    dx = cell_sizes[0, :]
+    dy = cell_sizes[1, :]
     dx = np.min(abs(dx[dx != 0])).item()
     dy = -np.min(abs(dy[dy != 0])).item()
 

--- a/cherab/tools/inversions/admt_utils.py
+++ b/cherab/tools/inversions/admt_utils.py
@@ -1,0 +1,63 @@
+"""
+Contains functions required to perform ADMT regularisation.
+
+This is based on work by L. C. Ingesson: see JET-R(99)08 available at
+http://www.euro-fusionscipub.org/wp-content/uploads/2014/11/JETR99008.pdf
+for details.
+"""
+
+
+def generate_derivative_operators(voxel_coords, grid_1d_to_2d_map,
+                                  grid_2d_to_1d_map):
+    r"""
+    Generate the first and second derivative operators for a regular grid.
+
+    :param ndarray voxel_coords: an Nx2 array of coordinates of the
+    centre of each voxel, (R, Z)
+    :param dict grid_flat_to_2d_map: a mapping from the 1D array of
+    voxels in the grid to a 2D array of voxels if they were arranged
+    spatially.
+    :param dict grid_2d_to_1d_map: the inverse mapping from a 2D
+    spatially-arranged array of voxels to the 1D array.
+
+    :return tuple operators: a named tuple containing the derivative
+    operators: Dij for i, y ∊ (x, y) and Di for i ∊ (x, y).
+
+    This function assumes that all voxels are rectilinear, with their
+    axes aligned to the coordinate axes. If this is not the case, the
+    results will be nonsense.
+
+    The return tuple contains all the first and second derivative
+    operators:
+
+    .. math::
+        D_{xx} \equiv \frac{\partial^2}{\partial x^2}\\
+        D_{xy} \equiv \frac{\partial^2}{\partial x \partial y}
+
+    etc.
+    """
+    return
+
+
+def calculate_admt(voxel_radii, derivative_operators, psi_at_voxels, anisotropy=10):
+    r"""
+    Calculate the ADMT regularisation operator.
+
+    :param ndarray voxel_radii: a 1D array of the radius at the centre
+    of each voxel in the grid
+    :param tuple derivative_operators: a named tuple with the derivative
+    operators for the grid, as returned by :func:`generate_derivative_operators`
+    :param ndarray psi_at_voxels: the magnetic flux at the centre of
+    each voxel in the grid
+    :param float anisotropy: the ratio of the smoothing in the parallel
+    and perpendicular directions.
+
+    :return ndarray admt: the ADMT regularisation operator.
+
+    The degree of anisotropy dictates the relative suppression of
+    gradients in the directions parallel and perpendicular to the
+    magnetic field. For example, `anisotropy=10` implies parallel
+    gradients in solution are 10 times smaller than perpendicular
+    gradients.
+    """
+    return

--- a/cherab/tools/inversions/admt_utils.py
+++ b/cherab/tools/inversions/admt_utils.py
@@ -66,7 +66,7 @@ def generate_derivative_operators(voxel_coords, grid_index_1d_to_2d_map,
         ix, iy = grid_index_1d_to_2d_map[ith_cell]
 
         try:
-            n_left = grid_index_2d_to_1d_map[ix - 1, iy]  # neighbour 1, left of n0
+            n_left = grid_index_2d_to_1d_map[ix - 1, iy]  # left of n0
         except KeyError:
             at_left = True
         else:
@@ -74,15 +74,15 @@ def generate_derivative_operators(voxel_coords, grid_index_1d_to_2d_map,
             Dxx[ith_cell, n_left] = 1
 
         try:
-            n_below_left = grid_index_2d_to_1d_map[ix - 1, iy + 1]  # neighbour 2, below left of n0
+            n_below_left = grid_index_2d_to_1d_map[ix - 1, iy + 1]  # below left of n0
         except KeyError:
-            pass
             # KeyError does not necessarily mean bottom AND left
+            pass
         else:
             Dxy[ith_cell, n_below_left] = 1 / 4
 
         try:
-            n_below = grid_index_2d_to_1d_map[ix, iy + 1]  # neighbour 3, below n0
+            n_below = grid_index_2d_to_1d_map[ix, iy + 1]
         except KeyError:
             at_bottom = True
         else:
@@ -90,14 +90,14 @@ def generate_derivative_operators(voxel_coords, grid_index_1d_to_2d_map,
             Dyy[ith_cell, n_below] = 1
 
         try:
-            n_below_right = grid_index_2d_to_1d_map[ix + 1, iy + 1]  # neighbour 4, below right of n0
+            n_below_right = grid_index_2d_to_1d_map[ix + 1, iy + 1]
         except KeyError:
             pass
         else:
             Dxy[ith_cell, n_below_right] = -1 / 4
 
         try:
-            n_right = grid_index_2d_to_1d_map[ix + 1, iy]  # neighbour 5, right of n0
+            n_right = grid_index_2d_to_1d_map[ix + 1, iy]
         except KeyError:
             at_right = True
         else:
@@ -105,14 +105,14 @@ def generate_derivative_operators(voxel_coords, grid_index_1d_to_2d_map,
             Dxx[ith_cell, n_right] = 1
 
         try:
-            n_above_right = grid_index_2d_to_1d_map[ix + 1, iy - 1]  # neighbour 6, above right of n0
+            n_above_right = grid_index_2d_to_1d_map[ix + 1, iy - 1]
         except KeyError:
             pass
         else:
             Dxy[ith_cell, n_above_right] = 1 / 4
 
         try:
-            n_above = grid_index_2d_to_1d_map[ix, iy - 1]  # neighbour 7, above n0
+            n_above = grid_index_2d_to_1d_map[ix, iy - 1]
         except KeyError:
             at_top = True
         else:
@@ -120,7 +120,7 @@ def generate_derivative_operators(voxel_coords, grid_index_1d_to_2d_map,
             Dyy[ith_cell, n_above] = 1
 
         try:
-            n_above_left = grid_index_2d_to_1d_map[ix - 1, iy - 1]  # neighbour 8, above left of n0
+            n_above_left = grid_index_2d_to_1d_map[ix - 1, iy - 1]
         except KeyError:
             pass
         else:

--- a/cherab/tools/inversions/admt_utils.py
+++ b/cherab/tools/inversions/admt_utils.py
@@ -5,6 +5,8 @@ This is based on work by L. C. Ingesson: see JET-R(99)08 available at
 http://www.euro-fusionscipub.org/wp-content/uploads/2014/11/JETR99008.pdf
 for details.
 """
+__author__ = "Jack Lovell, Oak Ridge National Laboratory"
+
 import numpy as np
 
 
@@ -15,7 +17,7 @@ def generate_derivative_operators(voxel_coords, grid_index_1d_to_2d_map,
 
     :param ndarray voxel_coords: an Nx2 array of coordinates of the
     centre of each voxel, (R, Z)
-    :param dict grid_flat_to_2d_map: a mapping from the 1D array of
+    :param dict grid_1d_to_2d_map: a mapping from the 1D array of
     voxels in the grid to a 2D array of voxels if they were arranged
     spatially.
     :param dict grid_2d_to_1d_map: the inverse mapping from a 2D
@@ -25,8 +27,13 @@ def generate_derivative_operators(voxel_coords, grid_index_1d_to_2d_map,
     operators: Dij for i, y ∊ (x, y) and Di for i ∊ (x, y).
 
     This function assumes that all voxels are rectilinear, with their
-    axes aligned to the coordinate axes. If this is not the case, the
-    results will be nonsense.
+    axes aligned to the coordinate axes. Additionally, all voxels are
+    assumed to have the same width and height. If this is not the case,
+    the results will be nonsense.
+
+    The mappings between the 1D list of voxel coordinate and their
+    order in a 2D grid assume that the 2D grid would by indexed by
+    (x, y), with the y coordinate varying most quickly.
 
     The return dict contains all the first and second derivative
     operators:

--- a/cherab/tools/inversions/admt_utils.py
+++ b/cherab/tools/inversions/admt_utils.py
@@ -5,6 +5,25 @@ This is based on work by L. C. Ingesson: see JET-R(99)08 available at
 http://www.euro-fusionscipub.org/wp-content/uploads/2014/11/JETR99008.pdf
 for details.
 """
+
+# Copyright 2016-2018 Euratom
+# Copyright 2016-2018 United Kingdom Atomic Energy Authority
+# Copyright 2016-2018 Centro de Investigaciones Energéticas, Medioambientales y Tecnológicas
+#
+# Licensed under the EUPL, Version 1.1 or – as soon they will be approved by the
+# European Commission - subsequent versions of the EUPL (the "Licence");
+# You may not use this work except in compliance with the Licence.
+# You may obtain a copy of the Licence at:
+#
+# https://joinup.ec.europa.eu/software/page/eupl5
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied.
+#
+# See the Licence for the specific language governing permissions and limitations
+# under the Licence.
+
 __author__ = "Jack Lovell, Oak Ridge National Laboratory"
 
 from collections import Mapping

--- a/cherab/tools/tests/test_admt.py
+++ b/cherab/tools/tests/test_admt.py
@@ -18,8 +18,12 @@
 
 import unittest
 import numpy as np
+import matplotlib.pyplot as plt
 
-from cherab.tools.inversions import generate_derivative_operators
+from raysect.core import Point2D
+from cherab.core.math.samplers import sample2d_points
+from cherab.tools.inversions import ToroidalVoxelGrid
+from cherab.tools.inversions import generate_derivative_operators, calculate_admt
 
 class TestADMT(unittest.TestCase):
     """Tests for ADMT utilities
@@ -27,11 +31,6 @@ class TestADMT(unittest.TestCase):
     The derivative operators are tested to ensure that the results match
     equations 37-41 in JET-R(99)08.
     """
-
-    NROW = 3
-    NCOL = 3
-    DX = 2
-    DY = 1
 
     # Voxels are ordered in successive descending columns
     VOXEL_COORDS = [
@@ -45,6 +44,24 @@ class TestADMT(unittest.TestCase):
         [6, 3],
         [6, 2],
     ]
+
+    NROW = 3
+    NCOL = 3
+    DX = 2
+    DY = 1
+    # Option to generate voxels programatically if desired
+    # VOXEL_COORDS = []
+    # GRID_1D_TO_2D_MAP = {}
+    # GRID_2D_TO_1D_MAP = {}
+    # i = 0
+    # for xi in range(NCOL):
+    #     for yj in range(NROW):
+    #         VOXEL_COORDS.append([xi * DX + 1, (NROW - yj) * DY + 1])
+    #         GRID_1D_TO_2D_MAP[i] = (xi, yj)
+    #         GRID_2D_TO_1D_MAP[(xi, yj)] = i
+    #         i += 1
+
+    VOXEL_COORDS = np.asarray(VOXEL_COORDS)
 
     VOXEL_VERTICES = []
     for (h, k) in VOXEL_COORDS:
@@ -78,7 +95,8 @@ class TestADMT(unittest.TestCase):
         (2, 2): 8,
     }
 
-    VOXEL_TEST_DATA = np.arange(10, 19)**3  # Varying second derivatives
+    # Choose test data where the second derivative varies
+    VOXEL_TEST_DATA = np.arange(VOXEL_COORDS.shape[0], dtype=np.float64)**3 + 10
 
     # Voxels are ordered in descending columns, as per Ingesson
     VOXELS_2D = np.reshape(VOXEL_COORDS, (NROW, NCOL, 2))

--- a/cherab/tools/tests/test_admt.py
+++ b/cherab/tools/tests/test_admt.py
@@ -1,0 +1,190 @@
+# Copyright 2016-2018 Euratom
+# Copyright 2016-2018 United Kingdom Atomic Energy Authority
+# Copyright 2016-2018 Centro de Investigaciones Energéticas, Medioambientales y Tecnológicas
+#
+# Licensed under the EUPL, Version 1.1 or – as soon they will be approved by the
+# European Commission - subsequent versions of the EUPL (the "Licence");
+# You may not use this work except in compliance with the Licence.
+# You may obtain a copy of the Licence at:
+#
+# https://joinup.ec.europa.eu/software/page/eupl5
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied.
+#
+# See the Licence for the specific language governing permissions and limitations
+# under the Licence.
+
+import unittest
+import numpy as np
+import numpy.testing as npt
+
+from cherab.tools.inversions import generate_derivative_operators
+
+class TestADMT(unittest.TestCase):
+    """Tests for ADMT utilities"""
+
+    NROW = 3
+    NCOL = 3
+    DX = 2
+    DY = 1
+
+    # Voxels are ordered in successive descending columns
+    VOXEL_COORDS = [
+        [2, 4],
+        [2, 3],
+        [2, 2],
+        [4, 4],
+        [4, 3],
+        [4, 2],
+        [6, 4],
+        [6, 3],
+        [6, 2],
+    ]
+
+    VOXEL_VERTICES = []
+    for (h, k) in VOXEL_COORDS:
+        VOXEL_VERTICES.append(
+            [(h + DX / 2, k + DY / 2), (h + DX / 2, k - DY / 2),
+             (h - DX / 2, k - DY / 2), (h - DX / 2, k + DY / 2)]
+        )
+
+    # Note that in 2D the array is indexed (x, y), with y varying quickest
+    GRID_1D_TO_2D_MAP = {
+        0: (0, 0),
+        1: (0, 1),
+        2: (0, 2),
+        3: (1, 0),
+        4: (1, 1),
+        5: (1, 2),
+        6: (2, 0),
+        7: (2, 1),
+        8: (2, 2),
+    }
+
+    GRID_2D_TO_1D_MAP = {
+        (0, 0): 0,
+        (0, 1): 1,
+        (0, 2): 2,
+        (1, 0): 3,
+        (1, 1): 4,
+        (1, 2): 5,
+        (2, 0): 6,
+        (2, 1): 7,
+        (2, 2): 8,
+    }
+
+    VOXEL_TEST_DATA = np.arange(10, 19)**3  # Varying second derivatives
+
+    # Voxels are ordered in descending columns, as per Ingesson
+    VOXELS_2D = np.reshape(VOXEL_COORDS, (NROW, NCOL, 2))
+
+    TEST_DATA_2D = np.reshape(VOXEL_TEST_DATA, (NROW, NCOL))
+
+    DERIVATIVE_OPERATORS = generate_derivative_operators(
+        VOXEL_VERTICES, GRID_1D_TO_2D_MAP, GRID_2D_TO_1D_MAP
+    )
+
+    # TODO: generalise tests to more than 3x3 grid (use -1 for X, Y indices)
+
+    # Check that equations 38-41 in JET-R(99)08 are satisfied.
+    def test_dx(self):
+        """D/Dx (Equations 37)"""
+        DtestDx = self.DERIVATIVE_OPERATORS["Dx"] @ self.VOXEL_TEST_DATA
+        data = self.TEST_DATA_2D
+        for i in range(NROW):  # Test each row of the grid
+            i0 = self.GRID_2D_TO_1D_MAP[(0, i)]
+            i1 = self.GRID_2D_TO_1D_MAP[(1, i)]
+            i2 = self.GRID_2D_TO_1D_MAP[(2, i)]
+            yX = (data[2, i] - data[1, i]) / self.DX
+            y1 = (data[1, i] - data[0, i]) / self.DX
+            yx = (data[2, i] - data[0, i]) / (2 * self.DX)
+            npt.assert_equal(DtestDx[[i0, i1, i2]], (y1, yx, yX))
+
+    def test_dy(self):
+        """D/Dy (Equations 38)"""
+        DtestDy = self.DERIVATIVE_OPERATORS["Dy"] @ self.VOXEL_TEST_DATA
+        data = self.TEST_DATA_2D
+        for i in range(NCOL):  # Test each column of the grid
+            i0 = self.GRID_2D_TO_1D_MAP[(i, 0)]
+            i1 = self.GRID_2D_TO_1D_MAP[(i, 1)]
+            i2 = self.GRID_2D_TO_1D_MAP[(i, 2)]
+            yx = (data[i, 0] - data[i, 2]) / (2 * self.DY)
+            onex = (data[i, 0] - data[i, 1]) / self.DY
+            Yx = (data[i, 1] - data[i, 2]) / self.DY
+            npt.assert_equal(DtestDy[[i0, i1, i2]], (onex, yx, Yx))
+
+    def test_dxx(self):
+        """D/Dx2 (Equations 39)"""
+        DtestDxx = self.DERIVATIVE_OPERATORS["Dxx"] @ self.VOXEL_TEST_DATA
+        data = self.TEST_DATA_2D
+        for i in range(NROW):  # Test each row of the grid
+            i0 = self.GRID_2D_TO_1D_MAP[(0, i)]
+            i1 = self.GRID_2D_TO_1D_MAP[(1, i)]
+            i2 = self.GRID_2D_TO_1D_MAP[(2, i)]
+            yx = (data[2, i] + data[0, i] - 2 * data[1, i]) / self.DX**2
+            y1 = (data[1, i] - data[0, i]) / self.DX**2
+            yX = (data[2, i] - data[1, i]) / self.DX**2
+            npt.assert_equal(DtestDxx[[i0, i1, i2]], (y1, yx, yX))
+
+    def test_dyy(self):
+        """D/Dy2 (Equations 40)"""
+        DtestDyy = self.DERIVATIVE_OPERATORS["Dyy"] @ self.VOXEL_TEST_DATA
+        data = self.TEST_DATA_2D
+        for i in range(NCOL):  # Test each column of the grid
+            i0 = self.GRID_2D_TO_1D_MAP[(i, 0)]
+            i1 = self.GRID_2D_TO_1D_MAP[(i, 1)]
+            i2 = self.GRID_2D_TO_1D_MAP[(i, 2)]
+            yx = (data[i, 0] + data[i, 2] - 2 * data[i, 1]) / self.DY**2
+            onex = (data[i, 0] - data[i, 1]) / self.DY**2
+            Yx = (data[i, 1] - data[i, 2]) / self.DY**2
+            npt.assert_equal(DtestDyy[[i0, i1, i2]], (onex, yx, Yx))
+
+    def test_dxy(self):  # pylint: disable=too-many-locals
+        """D/DxDy (Equations 41)"""
+        DtestDxy = self.DERIVATIVE_OPERATORS["Dxy"] @ self.VOXEL_TEST_DATA
+        data = self.TEST_DATA_2D
+        dxdy = self.DX * self.DY
+        # Test corners of the grid (41f to 41i)
+        i00 = self.GRID_2D_TO_1D_MAP[(0, 0)]
+        iX0 = self.GRID_2D_TO_1D_MAP[(2, 0)]
+        i0Y = self.GRID_2D_TO_1D_MAP[(0, 2)]
+        iXY = self.GRID_2D_TO_1D_MAP[(2, 2)]
+        oneone = (data[1, 0] + data[0, 1] - data[0, 0] - data[1, 1]) / dxdy
+        oneX = (data[2, 0] + data[1, 1] - data[1, 0] - data[2, 1]) / dxdy
+        Y1 = (data[1, 1] + data[0, 2] - data[0, 1] - data[1, 2]) / dxdy
+        YX = (data[2, 1] + data[1, 2] - data[2, 2] - data[1, 1]) / dxdy
+        npt.assert_equal(DtestDxy[[i00, iX0, i0Y, iXY]],
+                         (oneone, oneX, Y1, YX))
+        # Test edges (41b-41e)
+        for i in range(3):
+            i1x = self.GRID_2D_TO_1D_MAP[(i, 0)]
+            iYx = self.GRID_2D_TO_1D_MAP[(i, 2)]
+            iy1 = self.GRID_2D_TO_1D_MAP[(0, i)]
+            iyX = self.GRID_2D_TO_1D_MAP[(2, i)]
+            if 0 < i < 2:
+                onex = ((data[i + 1, 0] + data[i - 1, 1] - data[i - 1, 0] - data[i + 1, 1])
+                        / (2 * dxdy))
+                Yx = ((data[i + 1, -2] + data[i - 1, -1] - data[i - 1, -2] - data[i + 1, -1])
+                      / (2 * dxdy))
+                y1 = ((data[1, i - 1] + data[0, i + 1] - data[0, i - 1] - data[1, i + 1])
+                      / (2 * dxdy))
+                yX = ((data[-1, i - 1] + data[-2, i + 1] - data[-2, i - 1] - data[-1, i + 1])
+                      / (2 * dxdy))
+                np.testing.assert_equal(DtestDxy[[i1x, iYx, iy1, iyX]],
+                                        (onex, Yx, y1, yX))
+        # Test inner (41a)
+        for i in range(3):
+            for j in range(3):
+                if 0 < i < 2:
+                    if 0 < j < 2:
+                        ixy = self.GRID_2D_TO_1D_MAP[(i, j)]
+                        yx = ((data[i + 1, j - 1] + data[i - 1, j + 1]
+                               - data[i - 1, j - 1] - data[i + 1, j + 1])
+                              / (4 * dxdy))
+                        self.assertEqual(DtestDxy[ixy], yx)
+
+
+    def test_objective(self):
+        pass

--- a/cherab/tools/tests/test_admt.py
+++ b/cherab/tools/tests/test_admt.py
@@ -93,7 +93,7 @@ class TestADMT(unittest.TestCase):
         """D/Dx (Equations 37)"""
         DtestDx = self.DERIVATIVE_OPERATORS["Dx"] @ self.VOXEL_TEST_DATA
         data = self.TEST_DATA_2D
-        for i in range(NROW):  # Test each row of the grid
+        for i in range(self.NROW):  # Test each row of the grid
             i0 = self.GRID_2D_TO_1D_MAP[(0, i)]
             i1 = self.GRID_2D_TO_1D_MAP[(1, i)]
             i2 = self.GRID_2D_TO_1D_MAP[(2, i)]
@@ -106,7 +106,7 @@ class TestADMT(unittest.TestCase):
         """D/Dy (Equations 38)"""
         DtestDy = self.DERIVATIVE_OPERATORS["Dy"] @ self.VOXEL_TEST_DATA
         data = self.TEST_DATA_2D
-        for i in range(NCOL):  # Test each column of the grid
+        for i in range(self.NCOL):  # Test each column of the grid
             i0 = self.GRID_2D_TO_1D_MAP[(i, 0)]
             i1 = self.GRID_2D_TO_1D_MAP[(i, 1)]
             i2 = self.GRID_2D_TO_1D_MAP[(i, 2)]
@@ -119,7 +119,7 @@ class TestADMT(unittest.TestCase):
         """D/Dx2 (Equations 39)"""
         DtestDxx = self.DERIVATIVE_OPERATORS["Dxx"] @ self.VOXEL_TEST_DATA
         data = self.TEST_DATA_2D
-        for i in range(NROW):  # Test each row of the grid
+        for i in range(self.NROW):  # Test each row of the grid
             i0 = self.GRID_2D_TO_1D_MAP[(0, i)]
             i1 = self.GRID_2D_TO_1D_MAP[(1, i)]
             i2 = self.GRID_2D_TO_1D_MAP[(2, i)]
@@ -132,7 +132,7 @@ class TestADMT(unittest.TestCase):
         """D/Dy2 (Equations 40)"""
         DtestDyy = self.DERIVATIVE_OPERATORS["Dyy"] @ self.VOXEL_TEST_DATA
         data = self.TEST_DATA_2D
-        for i in range(NCOL):  # Test each column of the grid
+        for i in range(self.NCOL):  # Test each column of the grid
             i0 = self.GRID_2D_TO_1D_MAP[(i, 0)]
             i1 = self.GRID_2D_TO_1D_MAP[(i, 1)]
             i2 = self.GRID_2D_TO_1D_MAP[(i, 2)]

--- a/cherab/tools/tests/test_admt.py
+++ b/cherab/tools/tests/test_admt.py
@@ -198,6 +198,24 @@ class TestADMT(unittest.TestCase):
                                     / (4 * dxdy))
                 self.assertEqual(eq_deriv, deriv, msg="Failed for ({}, {})".format(xi, yj))
 
+    def test_invalid_coords(self):
+        """Test for invalid voxel_coords input"""
+        with self.assertRaises(TypeError):
+            generate_derivative_operators(self.VOXEL_COORDS, self.GRID_1D_TO_2D_MAP,
+                                          self.GRID_2D_TO_1D_MAP)
+
+    def test_invalid_1d_2d_mapping(self):
+        """Test for invalid 1D->2D input"""
+        with self.assertRaises(TypeError):
+            generate_derivative_operators(self.VOXEL_VERTICES, self.VOXEL_COORDS,
+                                          self.GRID_2D_TO_1D_MAP)
+
+    def test_invalid_2d_1d_mapping(self):
+        """Test for invalid 2D->1D input"""
+        with self.assertRaises(TypeError):
+            generate_derivative_operators(self.VOXEL_VERTICES, self.GRID_2D_TO_1D_MAP,
+                                          self.TEST_DATA_2D)
+
     def test_objective(self):
         pass
 


### PR DESCRIPTION
This PR adds the calculation of a regularisation operator for anisotropic smoothing along flux surfaces, used in ADMT tomographic inversions such as those by JET's Tomo5 program. This is useful for highly underdetermined systems such as bolometry, where isotropic regularisation gives poor results and where the solution is known *a priori* to be flux-aligned.

## Examples

Reconstruction of JPN 90652 at t=52.75s.

Tomo5, for reference:
![tomo5](https://user-images.githubusercontent.com/4849151/57456890-5a604500-7266-11e9-9368-bdfa971f173f.png)

Using Cherab's regularised NNLS inversion, with isotropic regularisation:
![laplacian](https://user-images.githubusercontent.com/4849151/57456922-706e0580-7266-11e9-9a97-485c341523c2.png)

Using the new ADMT regularisation, again with regularised NNLS:
![admt](https://user-images.githubusercontent.com/4849151/57456945-7ebc2180-7266-11e9-910c-18756c38b33d.png)

The two Cherab inversions have had hyperparameters chosen so that the residuals are similar to those from Tomo5. Since these inversions are at lower resolution, and have fewer tunable hyperparameters, it is unlikely either will ever match Tomo5 exactly. However, the ADMT inversion clearly bears more resemblance to the Tomo5 inversion than the isotropic one.

## Limitations

- Only rectilinear, axis-aligned grids with all voxels having the same cross sectional area are supported.
- The degree of anisotropy is the same for the entire grid.