### PR TITLE
Make the least squares inversion API more consistent

### DIFF
--- a/cherab/tools/inversions/lstsq.py
+++ b/cherab/tools/inversions/lstsq.py
@@ -28,16 +28,13 @@ def invert_regularised_lstsq(w_matrix, b_vector, alpha=0.01, tikhonov_matrix=Non
     This is a thin wrapper around numpy.linalg.lstsq, which modifies
     the arguments to include the supplied Tikhonov regularisation matrix.
 
-    If tikhonov_matrix is None, the matrix used is alpha times the
-    identity matrix.
-
     :param np.ndarray w_matrix: The sensitivity matrix describing the coupling between the
       detectors and the voxels. Must be an array with shape :math:`(N_d, N_s)`.
     :param np.ndarray b_vector: The measured power/radiance vector with shape :math:`(N_d)`.
     :param float alpha: The regularisation hyperparameter :math:`\alpha` which determines
       the regularisation strength of the tikhonov matrix.
     :param np.ndarray tikhonov_matrix: The tikhonov regularisation matrix operator, an array
-      with shape :math:`(N_s, N_s)`.
+      with shape :math:`(N_s, N_s)`. If None, the identity matrix is used.
     :return: (x, residuals), the solution and residual vectors.
 
     .. code-block:: pycon
@@ -49,7 +46,9 @@ def invert_regularised_lstsq(w_matrix, b_vector, alpha=0.01, tikhonov_matrix=Non
     m, n = w_matrix.shape
 
     if tikhonov_matrix is None:
-        tikhonov_matrix = np.identity(n) * alpha
+        tikhonov_matrix = np.identity(n)
+
+    tikhonov_matrix = alpha * tikhonov_matrix
 
     # Extend W to have form ...
     c_matrix = np.zeros((m+n, n))

--- a/cherab/tools/inversions/nnls.py
+++ b/cherab/tools/inversions/nnls.py
@@ -29,16 +29,13 @@ def invert_regularised_nnls(w_matrix, b_vector, alpha=0.01, tikhonov_matrix=None
     This is a thin wrapper around scipy.optimize.nnls, which modifies
     the arguments to include the supplied Tikhonov regularisation matrix.
 
-    If tikhonov_matrix is None, the matrix used is alpha times the
-    identity matrix.
-
     :param np.ndarray w_matrix: The sensitivity matrix describing the coupling between the
       detectors and the voxels. Must be an array with shape :math:`(N_d, N_s)`.
     :param np.ndarray b_vector: The measured power/radiance vector with shape :math:`(N_d)`.
     :param float alpha: The regularisation hyperparameter :math:`\alpha` which determines
       the regularisation strength of the tikhonov matrix.
     :param np.ndarray tikhonov_matrix: The tikhonov regularisation matrix operator, an array
-      with shape :math:`(N_s, N_s)`.
+      with shape :math:`(N_s, N_s)`. If None, the identity matrix is used.
     :return: (x, norm), the solution vector and the residual norm.
 
     .. code-block:: pycon
@@ -50,7 +47,9 @@ def invert_regularised_nnls(w_matrix, b_vector, alpha=0.01, tikhonov_matrix=None
     m, n = w_matrix.shape
 
     if tikhonov_matrix is None:
-        tikhonov_matrix = np.identity(n) * alpha
+        tikhonov_matrix = np.identity(n)
+
+    tikhonov_matrix = alpha * tikhonov_matrix
 
     # Extend W to have form ...
     c_matrix = np.zeros((m+n, n))


### PR DESCRIPTION
Make the API match that of the regularised SART inversion: the scale
factor controlling the relative importance of the measurement and
regularisation is always applied to the Tikhonov matrix, whether it is
specified or not. If unspecified, the Tikhonov matrix defaults to the
identity matrix.

This means callers need to provide an un-scaled Tikhonov matrix if
they want a custom regularisation scheme (such as isotropic smoothness
or ADMT).

Resolves #109 