### PR TITLE
Bugfix/emissivities from function

### DIFF
--- a/cherab/tools/tests/test_voxels.py
+++ b/cherab/tools/tests/test_voxels.py
@@ -125,6 +125,7 @@ ARBITRARY_VOXEL_COORDS = [
     [(2, -1), (2, 2), (3, 4), (4, 3), (5, 0)],
 ]
 
+
 class TestCSGVoxels(unittest.TestCase):
     """Test cases for CSG voxels.
 
@@ -151,8 +152,8 @@ class TestCSGVoxels(unittest.TestCase):
             rinner = 0.5 * rmin
             zupper = 1.5 * zmax if zmax > 0 else 0.5 * zmax
             zlower = 0.5 * zmin if zmin > 0 else 1.5 * zmin
-            test_rs = np.linspace(rinner, router, int(100*(router-rinner)))
-            test_zs = np.linspace(zlower, zupper, int(100*(zupper-zlower)))
+            test_rs = np.linspace(rinner, router, int(100 * (router - rinner)))
+            test_zs = np.linspace(zlower, zupper, int(100 * (zupper - zlower)))
             voxel_vertex_points = [Point2D(*v) for v in voxel_coords]
             voxel = AxisymmetricVoxel(voxel_vertex_points, parent=None,
                                       primitive_type='csg')
@@ -268,34 +269,86 @@ class TestVoxelCalculations(unittest.TestCase):
             expected_emiss = emiss_function(0, 0, 0)
             self.assertEqual(emiss, expected_emiss)
 
-    @unittest.skipUnless(HAVE_QUADPY, "Need quadpy package for integration")
     def test_variable_emissivity_triangular(self):
         # Use the same seed as Raysect's random tests
         seed(1234567890)
 
+        quadpy_precalculated_emiss = {
+            ((4, 3), (3, 2), (2, -1)): 4.333333333333331,
+            ((4, 3), (3, -1), (2, -1)): 1.333333333333333,
+            ((4, 3), (3, 3), (2, -1)): 5.333333333333333,
+            ((4, 3), (3, -1), (2, 2)): 4.083333333333334,
+            ((4, 3), (3, 2), (2, 2)): 7.083333333333333,
+            ((4, 3), (3, -1), (2, 3)): 5.000000000000001,
+            ((4, 2), (3, -1), (2, 3)): 3.916666666666668,
+            ((4, -1), (3, -1), (2, 3)): 0.6666666666666656,
+            ((4, 3), (3, -1), (2, 3)): 5.000000000000001,
+            ((4, 2), (3, 3), (2, -1)): 4.250000000000001,
+            ((4, -1), (3, 3), (2, -1)): 0.9999999999999998,
+            ((4, 3), (3, 3), (2, -1)): 5.333333333333333,
+            ((4, -1), (3, 3), (2, 2)): 3.75,
+            ((4, -1), (3, 3), (2, -1)): 0.9999999999999998,
+            ((4, -1), (3, 3), (2, 3)): 4.666666666666663,
+            ((4, -1), (3, 2), (2, 3)): 3.6666666666666674,
+            ((4, -1), (3, -1), (2, 3)): 0.6666666666666656,
+            ((4, -1), (3, 3), (2, 3)): 4.666666666666663,
+            ((4, 3), (4, 2), (2, -1)): 4.833333333333337,
+            ((4, 3), (4, -1), (2, -1)): 1.3333333333333337,
+            ((4, 3), (4, -1), (2, 2)): 4.333333333333332,
+            ((4, 3), (4, -1), (2, -1)): 1.3333333333333337,
+            ((4, 3), (4, -1), (2, 3)): 5.333333333333333,
+            ((4, 2), (4, -1), (2, 3)): 4.166666666666666,
+            ((4, 3), (4, -1), (2, 3)): 5.333333333333333,
+            ((4, 2), (4, 3), (2, -1)): 4.833333333333332,
+            ((4, -1), (4, 3), (2, -1)): 1.3333333333333337,
+            ((4, -1), (4, 3), (2, 2)): 4.333333333333331,
+            ((4, -1), (4, 3), (2, -1)): 1.3333333333333337,
+            ((4, -1), (4, 3), (2, 3)): 5.333333333333331,
+            ((4, -1), (4, 2), (2, 3)): 4.166666666666665,
+            ((4, -1), (4, 3), (2, 3)): 5.333333333333331,
+            ((4, 3), (2, 2), (2, -1)): 3.833333333333334,
+            ((4, 3), (2, 3), (2, -1)): 4.666666666666666,
+            ((4, 3), (2, -1), (2, 2)): 3.833333333333334,
+            ((4, 3), (2, -1), (2, 3)): 4.666666666666666,
+            ((4, 2), (2, -1), (2, 3)): 3.666666666666666,
+            ((4, -1), (2, -1), (2, 3)): 0.6666666666666659,
+            ((4, 3), (2, -1), (2, 3)): 4.666666666666666,
+            ((4, 2), (2, 3), (2, -1)): 3.666666666666666,
+            ((4, -1), (2, 3), (2, -1)): 0.666666666666666,
+            ((4, 3), (2, 3), (2, -1)): 4.666666666666666,
+            ((4, -1), (2, 3), (2, 2)): 3.16666666666666,
+            ((4, -1), (2, 3), (2, -1)): 0.666666666666666,
+            ((4, -1), (2, 2), (2, 3)): 3.16666666666666,
+            ((4, -1), (2, -1), (2, 3)): 0.6666666666666659,
+        }
+
         def emiss_function(r, phi, z):
             return r * z
-        # This should be equal to the integrated emissivity divided by the area
+
         for polygon in TRIANGLE_VOXEL_COORDS:
             coords = np.asarray(polygon)
             voxel_vertex_points = [Point2D(*v) for v in coords]
             voxel = AxisymmetricVoxel(voxel_vertex_points, parent=None)
             nsamples = 10000
             emiss = voxel.emissivity_from_function(emiss_function, nsamples)
-            # TODO: include pre-calculated values of expected emissivity
-            # for when quadpy is not installed
-            # Calculate the expected emissivity analytically
-            x1, y1 = coords[0]
-            x2, y2 = coords[1]
-            x3, y3 = coords[2]
-            triangle_area = 0.5 * abs(x1 * y2 + x2 * y3 + x3 * y1
-                                      - x2 * y1 - x3 * y2 - x1 * y3)
-            # Doesn't make any sense to sample from a <2D cross section area
-            if triangle_area == 0:
-                return
-            expected_emiss = quadpy.triangle.integrate(
-                lambda x: emiss_function(x[0], 0, x[1]), coords, quadpy.triangle.Strang(6)
-            ) / triangle_area
+            if HAVE_QUADPY:
+                # Calculate the expected emissivity
+                x1, y1 = coords[0]
+                x2, y2 = coords[1]
+                x3, y3 = coords[2]
+                triangle_area = 0.5 * abs(x1 * y2 + x2 * y3 + x3 * y1
+                                          - x2 * y1 - x3 * y2 - x1 * y3)
+                # Doesn't make any sense to sample from a <2D cross section area
+                if triangle_area == 0:
+                    continue
+                expected_emiss = quadpy.triangle.integrate(
+                    lambda x: emiss_function(x[0], 0, x[1]), coords, quadpy.triangle.Strang(6)
+                ) / triangle_area
+            else:
+                try:
+                    expected_emiss = quadpy_precalculated_emiss[tuple(polygon)]
+                except KeyError:  # For triangles with zero area
+                    continue
             max_relative_error = 0.0723  # Measured with seed(1234567890)
             self.assertAlmostEqual(emiss, expected_emiss, delta=emiss * max_relative_error)
 
@@ -305,7 +358,7 @@ class TestVoxelCalculations(unittest.TestCase):
 
         def emiss_function(r, phi, z):
             return r * z
-        # This should be equal to the integrated emissivity divided by the area
+
         # We can calculate the integrated emissivity analytically
         for polygon in RECTANGULAR_VOXEL_COORDS:
             coords = np.asarray(polygon)
@@ -322,39 +375,46 @@ class TestVoxelCalculations(unittest.TestCase):
             max_relative_error = 0.0221  # Measured with seed(1234567890)
             self.assertAlmostEqual(emiss, expected_emiss, delta=emiss * max_relative_error)
 
-    @unittest.skipUnless(HAVE_QUADPY, "Need quadpy package for integration")
     def test_variable_emissivity_arbitrary(self):
         # Use the same seed as Raysect's random tests
         seed(1234567890)
 
+        quadpy_precalculated_emiss = {
+            ((2, -1), (2, 2), (3, 4), (4, 3), (4, -1)): 3.5833333333333326,
+            ((2, -1), (2, 2), (3, 4), (4, 3), (4, 0)): 4.349999999999999,
+            ((2, -1), (2, 2), (3, 4), (4, 3), (5, 0)): 4.0482456140350855,
+        }
+
         def emiss_function(r, phi, z):
             return r * z
-        # This should be equal to the integrated emissivity divided by the area
+
         for polygon in ARBITRARY_VOXEL_COORDS:
             coords = np.asarray(polygon)
             voxel_vertex_points = [Point2D(*v) for v in coords]
             voxel = AxisymmetricVoxel(voxel_vertex_points, parent=None)
             nsamples = 10000
             emiss = voxel.emissivity_from_function(emiss_function, nsamples)
-            # TODO: include pre-calculated values of expected emissivity
-            # for when quadpy is not installed
-            # Calculate the expected emissivity
-            triangle_indices = triangulate2d(coords)
-            triangles = coords[triangle_indices]
-            expected_emiss = 0
-            polygon_area = 0
-            for triangle in triangles:
-                # Calculate the area with the shoelace formula
-                x1, y1 = triangle[0]
-                x2, y2 = triangle[1]
-                x3, y3 = triangle[2]
-                triangle_area = 0.5 * abs(x1 * y2 + x2 * y3 + x3 * y1
-                                          - x2 * y1 - x3 * y2 - x1 * y3)
-                # Total emissivity is the area-weighted emissivity for each triangle
-                expected_emiss += quadpy.triangle.integrate(
-                    lambda x: emiss_function(x[0], 0, x[1]), triangle, quadpy.triangle.Strang(6)
-                )
-                polygon_area += triangle_area
-            expected_emiss /= polygon_area
+            if HAVE_QUADPY:
+                # Calculate the expected emissivity
+                triangle_indices = triangulate2d(coords)
+                triangles = coords[triangle_indices]
+                expected_emiss = 0
+                polygon_area = 0
+                for triangle in triangles:
+                    # Calculate the area with the shoelace formula
+                    x1, y1 = triangle[0]
+                    x2, y2 = triangle[1]
+                    x3, y3 = triangle[2]
+                    triangle_area = 0.5 * abs(x1 * y2 + x2 * y3 + x3 * y1
+                                              - x2 * y1 - x3 * y2 - x1 * y3)
+                    # Total emissivity is the area-weighted emissivity for each triangle
+                    expected_emiss += quadpy.triangle.integrate(
+                        lambda x: emiss_function(x[0], 0, x[1]), triangle, quadpy.triangle.Strang(6)
+                    )
+                    polygon_area += triangle_area
+                expected_emiss /= polygon_area
+            else:
+                # Use pre-calculated values from a machine which had quadpy
+                expected_emiss = quadpy_precalculated_emiss[tuple(polygon)]
             max_relative_error = 0.0225  # Measured with seed(1234567890)
             self.assertAlmostEqual(emiss, expected_emiss, delta=emiss * max_relative_error)


### PR DESCRIPTION
Fix a bug in the emissivities_from_function method of ToroidalVoxelGrid where only the first triangle of the cross section was being sampled from. A number of other improvements have been made:

- The calculation of the emissivity from function for each voxel has been moved into the AxisymmetricVoxel object, with the ToroidalVoxelGrid simply looping through each voxel.
- Additional typing to improve performance.
- Unit tests added for a variety of AxisymmetricVoxel shapes.
- Docstring modified to explicitly describe the required symmetry for the emission function in the AxisymmetricVoxel case.
- A few small style tidy ups

Fixes #142 