### PR TITLE
Enable test coverage reporting with coverage.py

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[run]
+plugins = Cython.Coverage
+source = cherab
+omit = *tests*

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ docs/build/
 build/
 .idea/
 .nfs*
+.coverage
+htmlcov*

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ import multiprocessing
 use_cython = True
 force = False
 profile = False
+line_profile = False
 
 if "--skip-cython" in sys.argv:
     use_cython = False
@@ -21,6 +22,10 @@ if "--profile" in sys.argv:
     profile = True
     del sys.argv[sys.argv.index("--profile")]
 
+if "--line-profile" in sys.argv:
+    line_profile = True
+    del sys.argv[sys.argv.index("--line-profile")]
+
 source_paths = ['cherab', 'demos']
 compilation_includes = [".", numpy.get_include()]
 compilation_args = []
@@ -28,6 +33,11 @@ cython_directives = {
     'language_level': 3
 }
 setup_path = path.dirname(path.abspath(__file__))
+
+if line_profile:
+    compilation_args.append("-DCYTHON_TRACE=1")
+    compilation_args.append("-DCYTHON_TRACE_NOGIL=1")
+    cython_directives["linetrace"] = True
 
 if use_cython:
 


### PR DESCRIPTION
To use the coverage reporting, the package needs to be built with
line tracing capability, using ./dev/build.sh --line-profile. Then
call `coverage run -m unittest` to both run all the unit tests and
produce the coverage report. `coverage html` will then produce a set
of nicely formatted web pages detailing the test coverage.

This has not yet been added to Cherab's CI steps, but it gives us the
option to do so once we're happy to publicise coverage status.