### PR TITLE
Add ArbitraryTotalRadiatedPower

### DIFF
--- a/cherab/core/model/plasma/total_radiated_power.pxd
+++ b/cherab/core/model/plasma/total_radiated_power.pxd
@@ -17,6 +17,9 @@
 # under the Licence.
 
 
+from raysect.core.math.function cimport Function3D
+from raysect.optical cimport Spectrum, Point3D, Vector3D
+
 from cherab.core.atomic.elements cimport Element
 from cherab.core.atomic.rates cimport LineRadiationPower, ContinuumPower
 from cherab.core.plasma cimport PlasmaModel
@@ -34,3 +37,10 @@ cdef class TotalRadiatedPower(PlasmaModel):
         ContinuumPower _prb_rate
 
     cdef int _populate_cache(self) except -1
+
+cdef class ArbitraryTotalRadiatedPower(PlasmaModel):
+
+    cdef:
+        Function3D _radiated_power
+
+    cpdef Spectrum emission(self, Point3D point, Vector3D direction, Spectrum spectrum)


### PR DESCRIPTION
This plasma model allows the user to specify total radiated power with a custom Function3D object which is independent of other plasma properties and atomic data. This is handy if you have an external source of the quantity for example a transport code.

Linked to #169 