### PR TITLE
Add max_distance option to BolometerFoil.calculate_etendue

### DIFF
--- a/cherab/tools/observers/bolometry.py
+++ b/cherab/tools/observers/bolometry.py
@@ -573,18 +573,19 @@ class BolometerFoil(TargettedPixel):
 
         return pipeline.samples.mean
 
-    def calculate_etendue(self, ray_count=10000, batches=10):
+    def calculate_etendue(self, ray_count=10000, batches=10, max_distance=1e999):
         """
         Calculates the etendue of this detector.
 
-        This function calculates the detectors etendue by evaluating the ratio of rays that
-        pass un-impeded through the detector's aperture. For this method to work, the detector
-        and its aperture structures should be the only primitives present in the scene. If any
-        other primitives are present, the results may be misleading.
+        This function calculates the detectors etendue by evaluating the fraction of rays that
+        pass un-impeded through the detector's aperture.
 
         :param int ray_count: The number of rays used per batch.
-        :param int batches: The number of batches used to estimate the error on the etendue
-          calculation.
+        :param int batches: The number of batches used to estimate the error on the etendue calculation.
+        :param float max_distance: The maximum distance from the detector to consider intersections.
+            If a ray makes it further than this, it is assumed to have passed through the aperture,
+            regardless of what it hits. Use this if there are other primitives present in the scene
+            which do not form the aperture.
         """
 
         if batches < 5:
@@ -621,7 +622,7 @@ class BolometerFoil(TargettedPixel):
                 while True:
 
                     # Find the next intersection point of the ray with the world
-                    intersection = world.hit(CoreRay(origin, direction))
+                    intersection = world.hit(CoreRay(origin, direction, max_distance))
 
                     if intersection is None:
                         passed += 1 * path_weight


### PR DESCRIPTION
This enables calculating the etendue in instances when the world
contains other primitives than just the detector and aperture.

This is required as part of the fix for https://github.com/cherab/jet/issues/8.