### PR TITLE
Fix Discrete2DMesh import

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - "3.6"
 install:
   - pip install cython>=0.28
-  - pip install numpy scipy matplotlib raysect>=0.5.6
+  - pip install numpy scipy matplotlib raysect>=0.6.0
   - dev/build.sh
 # command to run tests
 script: dev/test.sh

--- a/cherab/core/math/mask.pxd
+++ b/cherab/core/math/mask.pxd
@@ -18,8 +18,7 @@
 # See the Licence for the specific language governing permissions and limitations
 # under the Licence.
 
-from raysect.core.math.function cimport Discrete2DMesh
-from cherab.core.math cimport Function2D
+from raysect.core.math.function cimport Function2D, Discrete2DMesh
 
 
 cdef class PolygonMask2D(Function2D):

--- a/cherab/core/math/mask.pxd
+++ b/cherab/core/math/mask.pxd
@@ -18,7 +18,7 @@
 # See the Licence for the specific language governing permissions and limitations
 # under the Licence.
 
-from raysect.core.math.interpolators cimport Discrete2DMesh
+from raysect.core.math.function cimport Discrete2DMesh
 from cherab.core.math cimport Function2D
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ cython>=0.28
 numpy
 scipy
 matplotlib
-raysect>=0.5.6
+raysect>=0.6.0
 

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Topic :: Scientific/Engineering :: Physics"
     ],
-    install_requires=['numpy', 'scipy', 'matplotlib', 'raysect>=0.5.6', 'cython>=0.28'],
+    install_requires=['numpy', 'scipy', 'matplotlib', 'raysect>=0.6.0', 'cython>=0.28'],
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
Discrete2D moved from location "from raysect.core.math.interpolators cimport Discrete2DMesh"  to "from raysect.core.math.function cimport Discrete2DMesh"

this should make development branches of Raysect and CHERAB compatible

linked to #175 