### PR TITLE
Fix setting voxel emitter material and parent in init

### DIFF
--- a/cherab/tools/inversions/voxels.pyx
+++ b/cherab/tools/inversions/voxels.pyx
@@ -595,11 +595,9 @@ class ToroidalVoxelGrid(VoxelCollection):
         max_height = -1E999
 
         self._voxels = []
-        for i, voxel_vertices in enumerate(voxel_coordinates):
+        for voxel_vertices in voxel_coordinates:
 
             voxel = AxisymmetricVoxel(voxel_vertices, primitive_type=primitive_type)
-            if active == "all" or active == i:
-                voxel.parent = parent
             self._voxels.append(voxel)
 
             # Test and set extent values
@@ -616,6 +614,8 @@ class ToroidalVoxelGrid(VoxelCollection):
         self._max_radius = max_radius
         self._min_height = min_height
         self._max_height = max_height
+
+        self.set_active(active)
 
     @property
     def min_radius(self):


### PR DESCRIPTION
Ensure that the set_active behaviour of ToroidalVoxelGrid.__init__
matches that of ToroidalVoxelGrid.set_active: the voxel material and
parent should be set correctly for both active="all" and active=<int>.

Also add some unit tests for ToroidalVoxelGrid.

Fixes #179 

There's still a unit test missing for `ToroidalVoxelGrid.emissivities_from_function`. I'll add one once I've thought of a robust way to test this. Maybe sampling?