### PR TITLE
Fix urllib imports in OpenADAS install script

### DIFF
--- a/cherab/openadas/install.py
+++ b/cherab/openadas/install.py
@@ -19,7 +19,8 @@
 
 
 import os
-import urllib
+import urllib.parse
+import urllib.request
 
 from cherab.openadas import repository
 from cherab.openadas.parse import *


### PR DESCRIPTION
Fixes #185 

This should probably result in a 1.2.1 release, as it could otherwise prevent users from properly installing the latest version of cherab.