### PR TITLE
Fix: wrong orders of constants

### DIFF
--- a/cherab/core/utility/constants.pyx
+++ b/cherab/core/utility/constants.pyx
@@ -25,5 +25,5 @@ cdef:
     double DEGREES_TO_RADIANS = M_PI / 180
     double RADIANS_TO_DEGREES = 180 / M_PI
     double PLANCK_CONSTANT = 6.6260700400e-34
-    double ELECTRON_CLASSICAL_RADIUS = 2.8179403262 #[m], NIST, CODATA 2018: https://physics.nist.gov/cgi-bin/cuu/Value?re|search_for=electron+radius
-    double ELECTRON_REST_MASS = 9.1093837015 #[kg], NIST, CODATA 2018: https://physics.nist.gov/cgi-bin/cuu/Value?me
+    double ELECTRON_CLASSICAL_RADIUS = 2.8179403262e-15 #[m], NIST, CODATA 2018: https://physics.nist.gov/cgi-bin/cuu/Value?re|search_for=electron+radius
+    double ELECTRON_REST_MASS = 9.1093837015e-31 #[kg], NIST, CODATA 2018: https://physics.nist.gov/cgi-bin/cuu/Value?me


### PR DESCRIPTION
I forgot to add orders to the constants of electron rest mass and classical radius. I am a bit embarrassed  now ...