### PR TITLE
Fix periodicity check in ray transfer objects for cylindrical grids

### DIFF
--- a/cherab/tools/raytransfer/emitters.pyx
+++ b/cherab/tools/raytransfer/emitters.pyx
@@ -418,7 +418,7 @@ cdef class CylindricalRayTransferEmitter(RayTransferEmitter):
                  double rmin=0):
 
         cdef:
-            double def_integration_step, period
+            double def_integration_step, period, num_sectors
 
         def_integration_step = 0.1 * min(grid_steps[0], grid_steps[-1])
         integrator = integrator or CylindricalRayTransferIntegrator(def_integration_step)
@@ -428,7 +428,8 @@ cdef class CylindricalRayTransferEmitter(RayTransferEmitter):
         self._dphi = self._grid_steps[1]
         self._dz = self._grid_steps[2]
         period = self._grid_shape[1] * self._grid_steps[1]
-        if 360. % period > 1.e-3:
+        num_sectors = 360. / period
+        if abs(round(num_sectors) - num_sectors) > 1.e-3:
             raise ValueError("The period %.3f (grid_shape[1] * grid_steps[1]) is not a multiple of 360." % period)
         self._period = period
 

--- a/cherab/tools/raytransfer/raytransfer.py
+++ b/cherab/tools/raytransfer/raytransfer.py
@@ -182,7 +182,8 @@ class RayTransferCylinder(RayTransferObject):
 
     def __init__(self, radius_outer, height, n_radius, n_height, radius_inner=0, n_polar=1, period=360., step=None, voxel_map=None, mask=None,
                  parent=None, transform=None):
-        if 360. % period > 1.e-3:
+        num_sectors = 360. / period
+        if abs(round(num_sectors) - num_sectors) > 1.e-3:
             raise ValueError("The period %.3f is not a multiple of 360." % period)
         grid_shape = (n_radius, n_polar, n_height)
         dr = (radius_outer - radius_inner) / n_radius


### PR DESCRIPTION
This is a fix for #225.