### PR TITLE
Update CI to build against correct version of raysect

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - "3.6"
   - "3.7"
 env:
-  - NUMPY_VERSION=1.14.6
+  - NUMPY_VERSION=1.15.0
   - NUMPY_VERSION=1.16.6
   - NUMPY_VERSION=1.18.1
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,12 @@ python:
   - "3.6"
   - "3.7"
 env:
-  - NUMPY_VERSION=1.15.0
-  - NUMPY_VERSION=1.16.6
-  - NUMPY_VERSION=1.18.1
+  - NUMPY="numpy==1.15.0"
+  - NUMPY="numpy==1.16.6"
+  - NUMPY="numpy"
 install:
   - pip install cython>=0.28
-  - pip install numpy==$NUMPY_VERSION scipy matplotlib
+  - pip install "$NUMPY" scipy matplotlib
   - if [ "$TRAVIS_BRANCH" = "master" ]; then
        pip install raysect;
     else

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,11 @@ env:
 install:
   - pip install cython>=0.28
   - pip install numpy==$NUMPY_VERSION scipy matplotlib
-  - pip install raysect==0.7
+  - if [ "$TRAVIS_BRANCH" = "master" ]; then
+       pip install raysect;
+    else
+       pip install git+https://github.com/raysect/source@development;
+    fi
   - dev/build.sh
 # command to run tests
 script: dev/test.sh


### PR DESCRIPTION
As discussed in #227, there is a risk of CI builds failing if the Cherab and Raysect versions get out of sync. It is proposed that released versions of Cherab (i.e. all versions on the master branch) should be compatible with the latest publicly released version of Raysect at the time of the Cherab release. The development branch of Cherab should be compatible with the development branch of Raysect.

This PR modifies the Travis config file so that CI builds are done against the correct version of Raysect. This should ensure that all pull requests to master will be compatible with the released Raysect version, but pull requests to development and other branches will not fail.

Testing this was tricky, but #228 demonstrates that the PR is built against master for a merge to master, and this PR demonstrates a build against Raysect development.

Also, Raysect (and Cherab) depends on matplotlib, and the latest released matplotlib 3.3.0 has dropped support for Numpy <1.15. So the minimum version needs to be bumped to get all builds to pass.