### PR TITLE
Fix: Set plasma b_field and distribution default values

### DIFF
--- a/cherab/core/distribution.pxd
+++ b/cherab/core/distribution.pxd
@@ -34,6 +34,17 @@ cdef class DistributionFunction:
     cpdef double density(self, double x, double y, double z) except? -1e999
 
 
+cdef class ZeroDistribution(DistributionFunction):
+
+    cdef double evaluate(self, double x, double y, double z, double vx, double vy, double vz) except? -1e999
+
+    cpdef Vector3D bulk_velocity(self, double x, double y, double z)
+
+    cpdef double effective_temperature(self, double x, double y, double z) except? -1e999
+
+    cpdef double density(self, double x, double y, double z) except? -1e999
+
+
 cdef class Maxwellian(DistributionFunction):
 
     cdef readonly:

--- a/cherab/core/distribution.pxd
+++ b/cherab/core/distribution.pxd
@@ -35,14 +35,7 @@ cdef class DistributionFunction:
 
 
 cdef class ZeroDistribution(DistributionFunction):
-
-    cdef double evaluate(self, double x, double y, double z, double vx, double vy, double vz) except? -1e999
-
-    cpdef Vector3D bulk_velocity(self, double x, double y, double z)
-
-    cpdef double effective_temperature(self, double x, double y, double z) except? -1e999
-
-    cpdef double density(self, double x, double y, double z) except? -1e999
+    pass
 
 
 cdef class Maxwellian(DistributionFunction):
@@ -52,10 +45,3 @@ cdef class Maxwellian(DistributionFunction):
         VectorFunction3D _velocity
         double _atomic_mass
 
-    cdef double evaluate(self, double x, double y, double z, double vx, double vy, double vz) except? -1e999
-
-    cpdef Vector3D bulk_velocity(self, double x, double y, double z)
-
-    cpdef double effective_temperature(self, double x, double y, double z) except? -1e999
-
-    cpdef double density(self, double x, double y, double z) except? -1e999

--- a/cherab/core/distribution.pyx
+++ b/cherab/core/distribution.pyx
@@ -118,7 +118,7 @@ cdef class ZeroDistribution(DistributionFunction):
     """
 
     def __init__(self):
-        self.notifier = Notifier()
+        super().__init__()
 
     def __call__(self, double x, double y, double z, double vx, double vy, double vz):
         """

--- a/cherab/core/distribution.pyx
+++ b/cherab/core/distribution.pyx
@@ -110,6 +110,83 @@ cdef class DistributionFunction:
         raise NotImplementedError()
 
 
+cdef class ZeroDistribution(DistributionFunction):
+    """
+    A zero distribution function.
+
+    All distribution properties are zero.
+    """
+
+    def __init__(self):
+        self.notifier = Notifier()
+
+    def __call__(self, double x, double y, double z, double vx, double vy, double vz):
+        """
+        Evaluates the phase space density at the specified point in 6D phase space.
+
+        Wraps the cython evaluate() function for fast evaluation.
+
+        :param float x: position in meters
+        :param float y: position in meters
+        :param float z: position in meters
+        :param float vx: velocity in meters per second
+        :param float vy: velocity in meters per second
+        :param float vz: velocity in meters per second
+        :return: phase space density 0 s^3/m^6
+        """
+        return self.evaluate(x, y, z, vx, vy, vz)
+
+    cdef double evaluate(self, double x, double y, double z, double vx, double vy, double vz) except? -1e999:
+        """
+        Evaluates the phase space density at the specified point in 6D phase space.
+        
+        :param float x: position in meters
+        :param float y: position in meters
+        :param float z: position in meters
+        :param float vx: velocity in meters per second
+        :param float vy: velocity in meters per second
+        :param float vz: velocity in meters per second
+        :return: phase space density 0 s^3/m^6
+        """
+        return 0.0
+
+    cpdef Vector3D bulk_velocity(self, double x, double y, double z):
+        """
+        Evaluates the species' bulk velocity at the specified 3D coordinate.
+
+        :param float x: position in meters
+        :param float y: position in meters
+        :param float z: position in meters
+        :return: velocity vector (0, 0, 0) in m/s
+        :rtype: Vector3D
+        """
+        return Vector3D(0, 0, 0)
+
+    cpdef double effective_temperature(self, double x, double y, double z) except? -1e999:
+        """
+        Returns 0 species' effective temperature at the specified 3D coordinate.
+
+        :param float x: position in meters
+        :param float y: position in meters
+        :param float z: position in meters
+        :return: temperature 0 eV
+        :rtype: float
+        """
+        return 0.0
+
+    cpdef double density(self, double x, double y, double z) except? -1e999:
+        """
+        Returns 0 species' density.
+
+        :param float x: position in meters
+        :param float y: position in meters
+        :param float z: position in meters
+        :return: density 0 m^-3
+        :rtype: float
+        """
+        return 0.0
+
+
 cdef class Maxwellian(DistributionFunction):
     """
     A Maxwellian distribution function.

--- a/cherab/core/plasma/node.pyx
+++ b/cherab/core/plasma/node.pyx
@@ -20,12 +20,12 @@
 from cherab.core.utility import Notifier
 
 from cherab.core.species import SpeciesNotFound
-from raysect.optical cimport AffineMatrix3D
+from raysect.optical cimport AffineMatrix3D, Vector3D
 from raysect.optical.material.emitter.inhomogeneous cimport NumericalIntegrator
 
 from cherab.core.math cimport Function3D, autowrap_function3d
 from cherab.core.math cimport VectorFunction3D, autowrap_vectorfunction3d
-from cherab.core.distribution cimport DistributionFunction
+from cherab.core.distribution cimport DistributionFunction, ZeroDistribution
 from cherab.core.plasma.material cimport PlasmaMaterial
 cimport cython
 
@@ -323,8 +323,8 @@ cdef class Plasma(Node):
         self.notifier = Notifier()
 
         # plasma properties
-        self._b_field = None
-        self._electron_distribution = None
+        self.b_field = Vector3D(0, 0, 0)
+        self.electron_distribution = ZeroDistribution()
 
         # setup plasma composition handler and pass through notifications
         self._composition = Composition()

--- a/cherab/core/plasma/node.pyx
+++ b/cherab/core/plasma/node.pyx
@@ -323,8 +323,8 @@ cdef class Plasma(Node):
         self.notifier = Notifier()
 
         # plasma properties
-        self.b_field = Vector3D(0, 0, 0)
-        self.electron_distribution = ZeroDistribution()
+        self.b_field = None
+        self.electron_distribution = None
 
         # setup plasma composition handler and pass through notifications
         self._composition = Composition()
@@ -350,7 +350,12 @@ cdef class Plasma(Node):
 
     @b_field.setter
     def b_field(self, object value):
-        self._b_field = autowrap_vectorfunction3d(value)
+        # assign Vector3D(0, 0, 0) if None is passed
+        if value is None:
+            self._b_field = autowrap_vectorfunction3d(Vector3D(0, 0, 0))
+        else:
+            self._b_field = autowrap_vectorfunction3d(value)
+
         self._modified()
 
     # cython fast access
@@ -362,8 +367,8 @@ cdef class Plasma(Node):
         return self._electron_distribution
 
     @electron_distribution.setter
-    def electron_distribution(self, value):
-        #assign ZeroDistribution if None value passed
+    def electron_distribution(self, DistributionFunction value):
+        # assign ZeroDistribution if None value passed
         if value is None:
             self._electron_distribution = ZeroDistribution()
         else:

--- a/cherab/core/plasma/node.pyx
+++ b/cherab/core/plasma/node.pyx
@@ -363,7 +363,12 @@ cdef class Plasma(Node):
 
     @electron_distribution.setter
     def electron_distribution(self, value):
-        self._electron_distribution = value
+        #assign ZeroDistribution if None value passed
+        if value is None:
+            self._electron_distribution = ZeroDistribution()
+        else:
+            self._electron_distribution = value
+
         self._modified()
 
     # cython fast access


### PR DESCRIPTION
None default values in plasma can cause segmentation fault
Added ZeroDistribution returning zero values
On default b_field is set to Vector3D(0, 0, 0)
On default electron_distribution is set to ZeroDistribution