### PR TITLE
Revert to specifying explicit versions of Numpy to test against.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,13 @@ python:
   - "3.6"
   - "3.7"
 env:
-  - NUMPY="numpy==1.15.0"
-  - NUMPY="numpy==1.16.6"
-  - NUMPY="numpy"
+  - NUMPY="1.15.0"
+  - NUMPY="1.16.6"
+  - NUMPY="1.19.2"
 install:
   - pip install cython>=0.28
-  - pip install "$NUMPY" scipy matplotlib
+  - pip install numpy=="$NUMPY"
+  - pip install scipy matplotlib
   - if [ "$TRAVIS_BRANCH" = "master" ]; then
        pip install raysect;
     else


### PR DESCRIPTION
Test 1.15.0 (earliest supported by matplotlib 3), 1.16.6 and 1.19.2 (latest at time of writing).

Fixes #227 