### PR TITLE
Replace electron temperature with species temperature in GaussianLine and MultipletLineShape to fix #235.

### DIFF
--- a/cherab/core/model/lineshape.pyx
+++ b/cherab/core/model/lineshape.pyx
@@ -168,11 +168,11 @@ cdef class GaussianLine(LineShapeModel):
     @cython.cdivision(True)
     cpdef Spectrum add_line(self, double radiance, Point3D point, Vector3D direction, Spectrum spectrum):
 
-        cdef double te, sigma, shifted_wavelength
+        cdef double ts, sigma, shifted_wavelength
         cdef Vector3D ion_velocity
 
-        te = self.plasma.get_electron_distribution().effective_temperature(point.x, point.y, point.z)
-        if te <= 0.0:
+        ts = self.target_species.distribution.effective_temperature(point.x, point.y, point.z)
+        if ts <= 0.0:
             return spectrum
 
         ion_velocity = self.target_species.distribution.bulk_velocity(point.x, point.y, point.z)
@@ -181,7 +181,7 @@ cdef class GaussianLine(LineShapeModel):
         shifted_wavelength = doppler_shift(self.wavelength, direction, ion_velocity)
 
         # calculate the line width
-        sigma = thermal_broadening(self.wavelength, te, self.line.element.atomic_weight)
+        sigma = thermal_broadening(self.wavelength, ts, self.line.element.atomic_weight)
 
         return add_gaussian_line(radiance, shifted_wavelength, sigma, spectrum)
 
@@ -243,17 +243,17 @@ cdef class MultipletLineShape(LineShapeModel):
     @cython.initializedcheck(False)
     cpdef Spectrum add_line(self, double radiance, Point3D point, Vector3D direction, Spectrum spectrum):
 
-        cdef double te, sigma, shifted_wavelength, component_wavelength, component_radiance
+        cdef double ts, sigma, shifted_wavelength, component_wavelength, component_radiance
         cdef Vector3D ion_velocity
 
-        te = self.plasma.get_electron_distribution().effective_temperature(point.x, point.y, point.z)
-        if te <= 0.0:
+        ts = self.target_species.distribution.effective_temperature(point.x, point.y, point.z)
+        if ts <= 0.0:
             return spectrum
 
         ion_velocity = self.target_species.distribution.bulk_velocity(point.x, point.y, point.z)
 
         # calculate the line width
-        sigma = thermal_broadening(self.wavelength, te, self.line.element.atomic_weight)
+        sigma = thermal_broadening(self.wavelength, ts, self.line.element.atomic_weight)
 
         for i in range(self._number_of_lines):
 


### PR DESCRIPTION
This fixes #235 by replacing the electron temperature with the temperature of the target species when calculating thermal broadening of the spectral lines in `GaussianLine` and `MultipletLineShape`.