### PR TITLE
Update import of float functions in Cherab demos to match Raysect 0.7 API

### DIFF
--- a/demos/observers/bolometry/geometry_matrix_with_voxels.py
+++ b/demos/observers/bolometry/geometry_matrix_with_voxels.py
@@ -13,7 +13,7 @@ from matplotlib.patches import Rectangle
 import numpy as np
 
 from raysect.core import Node, Point2D, Point3D, Vector3D, rotate_basis, rotate_y, translate
-from raysect.core.math import Arg2D
+from raysect.core.math.function.float import Arg2D
 from raysect.optical import World
 from raysect.optical.material import AbsorbingSurface
 from raysect.primitive import Box, Cylinder, Subtract

--- a/demos/plasmas/mesh_plasma.py
+++ b/demos/plasmas/mesh_plasma.py
@@ -23,7 +23,7 @@ import matplotlib.pyplot as plt
 from scipy.constants import electron_mass, atomic_mass
 from scipy.spatial import Delaunay
 
-from raysect.core.math import Interpolator2DMesh
+from raysect.core.math.function.float import Interpolator2DMesh
 from raysect.primitive import Cylinder
 from raysect.optical import World, translate, Point3D, Vector3D, rotate_basis, Spectrum
 from raysect.optical.observer import PinholeCamera, PowerPipeline2D


### PR DESCRIPTION
The following two demos are updated to fix #241:

- plasmas/mesh_plasma.py
- observers/bolometry/geometry_matrix_with_voxels.py
