### PR TITLE
Fix missing int to str conversion for charge in _update_and_write_adf11(), which caused #243.

### DIFF
--- a/cherab/openadas/repository/atomic.py
+++ b/cherab/openadas/repository/atomic.py
@@ -186,7 +186,7 @@ def _update_and_write_adf11(species, rate_data, path):
                 raise ValueError('Electron temperature, density and rate data arrays have inconsistent sizes.')
 
             # update file content with new rate
-            content[charge] = {
+            content[str(charge)] = {
                 'te': te.tolist(),
                 'ne': ne.tolist(),
                 'rate': rate_table.tolist(),

--- a/cherab/openadas/repository/radiated_power.py
+++ b/cherab/openadas/repository/radiated_power.py
@@ -182,7 +182,7 @@ def _update_and_write_adf11(species, rate_data, path):
             raise ValueError('Electron temperature, density and rate data arrays have inconsistent sizes.')
 
         # update file content with new rate
-        content[charge] = {
+        content[str(charge)] = {
             'te': te.tolist(),
             'ne': ne.tolist(),
             'rate': rate_table.tolist(),


### PR DESCRIPTION
This fixes #243 by converting integer `charge` to str when updating the content of existing .json file in `_update_and_write_adf11()`.