### PR TITLE
Fix incorrect inheritance of TotalRadiatedPower from _RadiatedPower class

### DIFF
--- a/cherab/core/atomic/rates.pxd
+++ b/cherab/core/atomic/rates.pxd
@@ -70,6 +70,14 @@ cdef class BeamEmissionPEC(_BeamRate):
     pass
 
 
+cdef class TotalRadiatedPower():
+
+    cdef:
+        readonly Element element
+
+    cdef double evaluate(self, double electron_density, double electron_temperature) except? -1e999
+
+
 cdef class _RadiatedPower:
 
     cdef:
@@ -77,10 +85,6 @@ cdef class _RadiatedPower:
         readonly int charge
 
     cdef double evaluate(self, double electron_density, double electron_temperature) except? -1e999
-
-
-cdef class TotalRadiatedPower(_RadiatedPower):
-    pass
 
 
 cdef class LineRadiationPower(_RadiatedPower):

--- a/cherab/core/atomic/rates.pxd
+++ b/cherab/core/atomic/rates.pxd
@@ -70,7 +70,7 @@ cdef class BeamEmissionPEC(_BeamRate):
     pass
 
 
-cdef class TotalRadiatedPower():
+cdef class TotalRadiatedPower:
 
     cdef:
         readonly Element element

--- a/cherab/core/atomic/rates.pyx
+++ b/cherab/core/atomic/rates.pyx
@@ -220,8 +220,36 @@ cdef class BeamEmissionPEC(_BeamRate):
     pass
 
 
+cdef class TotalRadiatedPower():
+    """The total radiated power in equilibrium conditions."""
+
+    def __init__(self, Element element):
+
+        self.element = element
+
+    def __call__(self, double electron_density, double electron_temperature):
+        """
+        Evaluate the radiated power rate at the given plasma conditions.
+
+        Calls the cython evaluate() method under the hood.
+
+        :param float electron_density: electron density in m^-3
+        :param float electron_temperature: electron temperature in eV
+        """
+        return self.evaluate(electron_density, electron_temperature)
+
+    cdef double evaluate(self, double electron_density, double electron_temperature) except? -1e999:
+        """
+        Evaluate the radiated power at the given plasma conditions.
+
+        :param float electron_density: electron density in m^-3
+        :param float electron_temperature: electron temperature in eV
+        """
+        raise NotImplementedError("The evaluate() virtual method must be implemented.")
+
+
 cdef class _RadiatedPower:
-    """Base class for radiated powers."""
+    """Base class for ionisation-resolved radiated powers."""
 
     def __init__(self, Element element, int charge):
 
@@ -247,11 +275,6 @@ cdef class _RadiatedPower:
         :param float electron_temperature: electron temperature in eV
         """
         raise NotImplementedError("The evaluate() virtual method must be implemented.")
-
-
-cdef class TotalRadiatedPower(_RadiatedPower):
-    """The total radiated power in equilibrium conditions."""
-    pass
 
 
 cdef class LineRadiationPower(_RadiatedPower):


### PR DESCRIPTION
This fixes #247. `TotalRadiatedPower` is now a base class and no longer requires an ionisation argument to initialise.