### PR TITLE
Add pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "numpy>=1.14", "cython>=0.28", "raysect==0.7"]


### PR DESCRIPTION
This specifies the build dependencies so that installations of Cherab
can be done from scratch (e.g. in a fresh virtualenv or on a new
system) using `pip install <path-to-cherab>`, or on systems where a
Cherab wheel is not available.

Note that the versions of dependencies in pyproject.toml should be
kept in sync with setup.py's `install_requires`, and also with
requirements.txt. However, with the addition of pyproject.toml it is
likely that requirements.txt is no longer needed.

Fixes #240 