### PR TITLE
Fix NumPy 1.20+ deprecation warnings (issue #281).

### DIFF
--- a/cherab/tools/raytransfer/emitters.pyx
+++ b/cherab/tools/raytransfer/emitters.pyx
@@ -310,9 +310,9 @@ cdef class RayTransferEmitter(InhomogeneousVolumeEmitter):
         if mask is not None:
             if mask.shape != self.grid_shape:
                 raise ValueError('Mask array must be of shape: %s.' % (' '.join(['%d' % i for i in self._grid_shape])))
-            mask = mask.astype(np.bool)
+            mask = mask.astype(bool)
         else:
-            mask = np.ones(self.grid_shape, dtype=np.bool)
+            mask = np.ones(self.grid_shape, dtype=bool)
         voxel_map = -1 * np.ones(mask.shape, dtype=np.int32)
         voxel_map[mask] = np.arange(mask.sum(), dtype=np.int32)
 

--- a/cherab/tools/tests/test_raytransfer.py
+++ b/cherab/tools/tests/test_raytransfer.py
@@ -31,22 +31,22 @@ class TestRayTransferCylinder(unittest.TestCase):
 
     def test_mask_2d(self):
         rtc = RayTransferCylinder(radius_outer=8., height=10., n_radius=4, n_height=10, radius_inner=4.)
-        mask = np.zeros((4, 10), dtype=np.bool)
+        mask = np.zeros((4, 10), dtype=bool)
         mask[:, 3:6] = True
         rtc.mask = mask[:, None, :]
-        voxel_map_ref = -1 * np.ones((4, 10), dtype=np.int)
+        voxel_map_ref = -1 * np.ones((4, 10), dtype=np.int32)
         voxel_map_ref[:, 3:6] = np.arange(12, dtype=int).reshape((4, 3))
         self.assertTrue(np.all(voxel_map_ref == rtc.voxel_map[:, 0, :]) and rtc.bins == 12)
 
     def test_voxel_map_2d(self):
         rtc = RayTransferCylinder(radius_outer=8., height=10., n_radius=4, n_height=10, radius_inner=4.)
-        voxel_map = -1 * np.ones((4, 10), dtype=np.int)
+        voxel_map = -1 * np.ones((4, 10), dtype=np.int32)
         voxel_map[1, 3:5] = 0
         voxel_map[2, 3:5] = 1
         voxel_map[1, 5:7] = 2
         voxel_map[2, 5:7] = 3
         rtc.voxel_map = voxel_map[:, None, :]
-        mask_ref = np.zeros((4, 10), dtype=np.bool)
+        mask_ref = np.zeros((4, 10), dtype=bool)
         mask_ref[1:3, 3:7] = True
         inv_vmap_ref = [(np.array([1, 1]), np.array([3, 4])), (np.array([2, 2]), np.array([3, 4])),
                         (np.array([1, 1]), np.array([5, 6])), (np.array([2, 2]), np.array([5, 6]))]
@@ -56,16 +56,16 @@ class TestRayTransferCylinder(unittest.TestCase):
 
     def test_mask_3d(self):
         rtc = RayTransferCylinder(radius_outer=8., height=10., n_radius=4, n_height=10, radius_inner=4., n_polar=10, period=10.)
-        mask = np.zeros((4, 10, 10), dtype=np.bool)
+        mask = np.zeros((4, 10, 10), dtype=bool)
         mask[1:3, 3:8, 4:6] = True
         rtc.mask = mask
-        voxel_map_ref = -1 * np.ones((4, 10, 10), dtype=np.int)
+        voxel_map_ref = -1 * np.ones((4, 10, 10), dtype=np.int32)
         voxel_map_ref[1:3, 3:8, 4:6] = np.arange(20, dtype=int).reshape((2, 5, 2))
         self.assertTrue(np.all(voxel_map_ref == rtc.voxel_map) and rtc.bins == 20)
 
     def test_voxel_map_3d(self):
         rtc = RayTransferCylinder(radius_outer=8., height=10., n_radius=4, n_height=10, radius_inner=4., n_polar=10, period=10.)
-        voxel_map = -1 * np.ones((4, 10, 10), dtype=np.int)
+        voxel_map = -1 * np.ones((4, 10, 10), dtype=np.int32)
         voxel_map[1, 3:5, 3:5] = 0
         voxel_map[2, 3:5, 3:5] = 1
         voxel_map[1, 5:7, 3:5] = 2
@@ -75,7 +75,7 @@ class TestRayTransferCylinder(unittest.TestCase):
         voxel_map[1, 5:7, 5:7] = 6
         voxel_map[2, 5:7, 5:7] = 7
         rtc.voxel_map = voxel_map
-        mask_ref = np.zeros((4, 10, 10), dtype=np.bool)
+        mask_ref = np.zeros((4, 10, 10), dtype=bool)
         mask_ref[1:3, 3:7, 3:7] = True
         inv_vmap_ref = [(np.array([1, 1, 1, 1]), np.array([3, 3, 4, 4]), np.array([3, 4, 3, 4])),
                         (np.array([2, 2, 2, 2]), np.array([3, 3, 4, 4]), np.array([3, 4, 3, 4])),
@@ -124,16 +124,16 @@ class TestRayTransferBox(unittest.TestCase):
 
     def test_mask(self):
         rtb = RayTransferBox(xmax=10., ymax=10., zmax=10., nx=10, ny=10, nz=10)
-        mask = np.zeros((10, 10, 10), dtype=np.bool)
+        mask = np.zeros((10, 10, 10), dtype=bool)
         mask[5:7, 5:7, 5:7] = True
         rtb.mask = mask
-        voxel_map_ref = -1 * np.ones((10, 10, 10), dtype=np.int)
+        voxel_map_ref = -1 * np.ones((10, 10, 10), dtype=np.int32)
         voxel_map_ref[5:7, 5:7, 5:7] = np.arange(8, dtype=int).reshape((2, 2, 2))
         self.assertTrue(np.all(voxel_map_ref == rtb.voxel_map) and rtb.bins == 8)
 
     def test_voxel_map(self):
         rtb = RayTransferBox(xmax=10., ymax=10., zmax=10., nx=10, ny=10, nz=10)
-        voxel_map = -1 * np.ones((10, 10, 10), dtype=np.int)
+        voxel_map = -1 * np.ones((10, 10, 10), dtype=np.int32)
         voxel_map[:2, :2, :2] = 0
         voxel_map[:2, :2, 8:] = 1
         voxel_map[:2, 8:, :2] = 2
@@ -143,7 +143,7 @@ class TestRayTransferBox(unittest.TestCase):
         voxel_map[8:, 8:, :2] = 6
         voxel_map[8:, 8:, 8:] = 7
         rtb.voxel_map = voxel_map
-        mask_ref = np.zeros((10, 10, 10), dtype=np.bool)
+        mask_ref = np.zeros((10, 10, 10), dtype=bool)
         mask_ref[:2, :2, :2] = True
         mask_ref[:2, :2, 8:] = True
         mask_ref[:2, 8:, :2] = True

--- a/demos/ray_transfer/4_ray_transfer_map.py
+++ b/demos/ray_transfer/4_ray_transfer_map.py
@@ -58,7 +58,7 @@ rtc.transform = translate(0, 0, -50.)
 rad_circle = 50.
 xsqr = np.linspace(-49.5, 49.5, 100) ** 2
 rad = np.sqrt(xsqr[:, None] + xsqr[None, :])
-voxel_map = np.zeros((100, 100), dtype=np.int)
+voxel_map = np.zeros((100, 100), dtype=np.int32)
 voxel_map[rad > 50.] = -1  # removing the area outside the circle
 for i in range(50):
     voxel_map[(rad < i + 1.) * (rad > i)] = i  # mapping multiple grid cells to a single light source


### PR DESCRIPTION
This fixes #281 by replacing deprecated `np.bool` with `bool` and `np.int` with `np.int32` in ray transfer objects and related tests and demos.