### PR TITLE
Update setup.py to require Raysect 0.7.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy>=1.14", "cython>=0.28", "raysect==0.7"]
+requires = ["setuptools", "wheel", "numpy>=1.14", "cython>=0.28", "raysect==0.7.1"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ cython>=0.28
 numpy>=1.14
 scipy
 matplotlib
-raysect==0.7
+raysect==0.7.1

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Topic :: Scientific/Engineering :: Physics"
     ],
-    install_requires=['numpy>=1.14', 'scipy', 'matplotlib', 'raysect==0.7', 'cython>=0.28'],
+    install_requires=['numpy>=1.14', 'scipy', 'matplotlib', 'raysect==0.7.1', 'cython>=0.28'],
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
For compatibility with the Raysect development branch, Cherab must require Raysect v 0.7.1, therefore setup.py must be updated. This fixes #305.