### PR TITLE
Fix a typo in RadiationFunction docstring

### DIFF
--- a/cherab/tools/emitters/radiation_function.pyx
+++ b/cherab/tools/emitters/radiation_function.pyx
@@ -40,7 +40,7 @@ cdef class RadiationFunction(InhomogeneousVolumeEmitter):
     evaluation takes place in the correct coordinate system.
 
     :param Function3D radiation_function: A 3D radiation function that specifies the amount of radiation
-      to be radiated at a given point, :math:`\phi(x, y, z)` [W/m^2].
+      to be radiated at a given point, :math:`\phi(x, y, z)` [W/m^3].
     :param float step: The scale length for integration of the radiation function.
 
     .. code-block:: pycon


### PR DESCRIPTION
This fixes a typo in `RadiationFunction` docstring and closes #308