### PR TITLE
fix: separate adas download caches

### DIFF
--- a/cherab/openadas/install.py
+++ b/cherab/openadas/install.py
@@ -83,7 +83,7 @@ def install_adf11scd(element, file_path, download=False, repository_path=None, a
     """
 
     print('Installing {}...'.format(file_path))
-    path = _locate_adas_file(file_path, download, adas_path)
+    path = _locate_adas_file(file_path, download, adas_path, repository_path)
     if not path:
         raise ValueError('Could not locate the specified ADAS file.')
 
@@ -107,7 +107,7 @@ def install_adf11acd(element, file_path, download=False, repository_path=None, a
     """
 
     print('Installing {}...'.format(file_path))
-    path = _locate_adas_file(file_path, download, adas_path)
+    path = _locate_adas_file(file_path, download, adas_path, repository_path)
     if not path:
         raise ValueError('Could not locate the specified ADAS file.')
 
@@ -135,7 +135,7 @@ def install_adf11ccd(donor_element, donor_charge, receiver_element, file_path, d
     """
 
     print('Installing {}...'.format(file_path))
-    path = _locate_adas_file(file_path, download, adas_path)
+    path = _locate_adas_file(file_path, download, adas_path, repository_path)
     if not path:
         raise ValueError('Could not locate the specified ADAS file.')
 
@@ -162,7 +162,7 @@ def install_adf11plt(element, file_path, download=False, repository_path=None, a
     """
 
     print('Installing {}...'.format(file_path))
-    path = _locate_adas_file(file_path, download, adas_path)
+    path = _locate_adas_file(file_path, download, adas_path, repository_path)
     if not path:
         raise ValueError('Could not locate the specified ADAS file.')
 
@@ -186,7 +186,7 @@ def install_adf11prb(element, file_path, download=False, repository_path=None, a
     """
 
     print('Installing {}...'.format(file_path))
-    path = _locate_adas_file(file_path, download, adas_path)
+    path = _locate_adas_file(file_path, download, adas_path, repository_path)
     if not path:
         raise ValueError('Could not locate the specified ADAS file.')
 
@@ -210,7 +210,7 @@ def install_adf11prc(element, file_path, download=False, repository_path=None, a
     """
 
     print('Installing {}...'.format(file_path))
-    path = _locate_adas_file(file_path, download, adas_path)
+    path = _locate_adas_file(file_path, download, adas_path, repository_path)
     if not path:
         raise ValueError('Could not locate the specified ADAS file.')
 
@@ -237,7 +237,7 @@ def install_adf12(donor_ion, donor_metastable, receiver_ion, receiver_charge, fi
     """
 
     print('Installing {}...'.format(file_path))
-    path = _locate_adas_file(file_path, download, adas_path)
+    path = _locate_adas_file(file_path, download, adas_path, repository_path)
     if not path:
         raise ValueError('Could not locate the specified ADAS file.')
 
@@ -259,7 +259,7 @@ def install_adf15(element, ionisation, file_path, download=False, repository_pat
     """
 
     print('Installing {}...'.format(file_path))
-    path = _locate_adas_file(file_path, download, adas_path)
+    path = _locate_adas_file(file_path, download, adas_path, repository_path)
     if not path:
         raise ValueError('Could not locate the specified ADAS file.')
 
@@ -280,7 +280,7 @@ def install_adf21(beam_species, target_ion, target_charge, file_path, download=F
     # """
 
     print('Installing {}...'.format(file_path))
-    path = _locate_adas_file(file_path, download, adas_path)
+    path = _locate_adas_file(file_path, download, adas_path, repository_path)
     if not path:
         raise ValueError('Could not locate the specified ADAS file.')
 
@@ -301,7 +301,7 @@ def install_adf22bmp(beam_species, beam_metastable, target_ion, target_charge, f
     # """
 
     print('Installing {}...'.format(file_path))
-    path = _locate_adas_file(file_path, download, adas_path)
+    path = _locate_adas_file(file_path, download, adas_path, repository_path)
     if not path:
         raise ValueError('Could not locate the specified ADAS file.')
 
@@ -322,7 +322,7 @@ def install_adf22bme(beam_species, target_ion, target_charge, transition, file_p
     # """
 
     print('Installing {}...'.format(file_path))
-    path = _locate_adas_file(file_path, download, adas_path)
+    path = _locate_adas_file(file_path, download, adas_path, repository_path)
     if not path:
         raise ValueError('Could not locate the specified ADAS file.')
 
@@ -331,9 +331,10 @@ def install_adf22bme(beam_species, target_ion, target_charge, transition, file_p
     repository.update_beam_emission_rates(rate, repository_path)
 
 
-def _locate_adas_file(file_path, download=False, adas_path=None):
+def _locate_adas_file(file_path, download=False, adas_path=None, repository_path=None):
 
     path = None
+    repository_path = repository_path or repository.utility.DEFAULT_REPOSITORY_PATH
 
     # is file in adas path?
     if adas_path:
@@ -343,7 +344,7 @@ def _locate_adas_file(file_path, download=False, adas_path=None):
 
     # download file?
     if not path and download:
-        target = os.path.join(ADAS_DOWNLOAD_CACHE, file_path)
+        target = os.path.join(repository_path, "_download_cache", file_path)
 
         # is file in cache? if not download...
         if os.path.isfile(target):

--- a/cherab/openadas/install.py
+++ b/cherab/openadas/install.py
@@ -27,7 +27,6 @@ from cherab.openadas.parse import *
 from cherab.core.utility import RecursiveDict, PerCm3ToPerM3, Cm3ToM3
 
 
-ADAS_DOWNLOAD_CACHE = os.path.expanduser('~/.cherab/openadas/download_cache')
 OPENADAS_FILE_URL = 'http://open.adas.ac.uk/download/'
 
 


### PR DESCRIPTION
Download caches for open adas data have to be separated to avoid
problems. The download cache moved to repository/_download_cache

related to #315 