### PR TITLE
Temporarily fix ci.yml to build Cherab against the released Raysect 0.7.1 regardless of branch.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install Python dependencies
       run: python -m pip install cython>=0.28 numpy==${{ matrix.numpy-version }} scipy matplotlib
-    - name: Install Raysect from pypi on master branch
-#       if: github.ref == 'refs/heads/master'
+    - name: Install Raysect from pypi
       run: pip install raysect
-#     - name: Install Raysect from github
-#       if: github.ref != 'refs/heads/master'
-#       run: pip install git+https://github.com/raysect/source@development
     - name: Build cherab
       run: dev/build.sh
     - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,11 @@ jobs:
     - name: Install Python dependencies
       run: python -m pip install cython>=0.28 numpy==${{ matrix.numpy-version }} scipy matplotlib
     - name: Install Raysect from pypi on master branch
-      if: github.ref == 'refs/heads/master'
+#       if: github.ref == 'refs/heads/master'
       run: pip install raysect
-    - name: Install Raysect from github
-      if: github.ref != 'refs/heads/master'
-      run: pip install git+https://github.com/raysect/source@development
+#     - name: Install Raysect from github
+#       if: github.ref != 'refs/heads/master'
+#       run: pip install git+https://github.com/raysect/source@development
     - name: Build cherab
       run: dev/build.sh
     - name: Run tests


### PR DESCRIPTION
This should fix #320 until the new version of Cherab is released and the development branch is updated to support Raysect 0.8.