### PR TITLE
Fix possible inconsistency in origin and direction

### DIFF
--- a/cherab/tools/observers/spectroscopy/base.py
+++ b/cherab/tools/observers/spectroscopy/base.py
@@ -43,24 +43,24 @@ class _SpectroscopicObserver0DBase:
     @property
     def origin(self):
         # The origin point of the sight line.
-        return self._origin
+        return Point3D(0, 0, 0).transform(self.transform)
 
     @origin.setter
     def origin(self, value):
         if not isinstance(value, Point3D):
             raise TypeError("Attribute 'origin' must be of type Point3D.")
-
-        if self._direction.x != 0 or self._direction.y != 0 or self._direction.z != 1:
+        
+        direction = self.direction
+        if direction.x != 0 or direction.y != 0 or direction.z != 1:
             up = Vector3D(0, 0, 1)
         else:
             up = Vector3D(1, 0, 0)
-        self._origin = value
-        self.transform = translate(value.x, value.y, value.z) * rotate_basis(self._direction, up)
+        self.transform = translate(value.x, value.y, value.z) * rotate_basis(direction, up)
 
     @property
     def direction(self):
         # The observation direction of the sight line.
-        return self._direction
+        return Vector3D(0, 0, 1).transform(self.transform)
 
     @direction.setter
     def direction(self, value):
@@ -71,8 +71,8 @@ class _SpectroscopicObserver0DBase:
             up = Vector3D(0, 0, 1)
         else:
             up = Vector3D(1, 0, 0)
-        self._direction = value
-        self.transform = translate(self._origin.x, self._origin.y, self._origin.z) * rotate_basis(value, up)
+        origin = self.origin
+        self.transform = translate(origin.x, origin.y, origin.z) * rotate_basis(value, up)
 
     @property
     def display_progress(self):

--- a/cherab/tools/observers/spectroscopy/fibreoptic.py
+++ b/cherab/tools/observers/spectroscopy/fibreoptic.py
@@ -34,8 +34,8 @@ class SpectroscopicFibreOptic(FibreOptic, _SpectroscopicObserver0DBase):
 
     Multiple `SpectroscopicFibreOptic` observers can be combined into `FibreOpticGroup`.
 
-    :param Point3D origin: The origin point for this sight-line.
-    :param Vector3D direction: The observation direction for this sight-line.
+    :param Point3D origin: The origin point for this sight-line. (optional)
+    :param Vector3D direction: The observation direction for this sight-line. (optional)
     :param list pipelines: A list of pipelines that will process the resulting spectra
                            from this observer.
                            Default is [SpectralRadiancePipeline0D(accumulate=False)].
@@ -63,13 +63,14 @@ class SpectroscopicFibreOptic(FibreOptic, _SpectroscopicObserver0DBase):
        >>> plt.show()
     """
 
-    def __init__(self, origin, direction, pipelines=None, acceptance_angle=None, radius=None, parent=None, name=None):
+    def __init__(self, origin=None, direction=None, pipelines=None, acceptance_angle=None, radius=None, parent=None, name=None):
 
-        self._origin = Point3D(0, 0, 0)
-        self._direction = Vector3D(1, 0, 0)
         pipelines = pipelines or [SpectralRadiancePipeline0D(accumulate=False)]
 
         super().__init__(pipelines=pipelines, parent=parent, name=name, acceptance_angle=acceptance_angle, radius=radius)
 
-        self.origin = origin
-        self.direction = direction
+        if origin is not None:
+            self.origin = origin
+
+        if direction is not None:
+            self.direction = direction

--- a/cherab/tools/observers/spectroscopy/sightline.py
+++ b/cherab/tools/observers/spectroscopy/sightline.py
@@ -31,8 +31,8 @@ class SpectroscopicSightLine(SightLine, _SpectroscopicObserver0DBase):
 
     Multiple `SpectroscopicSightLine` observers can be combined into `SightLineGroup`.
 
-    :param Point3D origin: The origin point for this sight-line.
-    :param Vector3D direction: The observation direction for this sight-line.
+    :param Point3D origin: The origin point for this sight-line. (optional)
+    :param Vector3D direction: The observation direction for this sight-line. (optional)
     :param list pipelines: A list of pipelines that will process the resulting spectra
                            from this observer.
                            Default is [SpectralRadiancePipeline0D(accumulate=False)].
@@ -54,13 +54,14 @@ class SpectroscopicSightLine(SightLine, _SpectroscopicObserver0DBase):
        >>> plt.show()
     """
 
-    def __init__(self, origin, direction, pipelines=None, parent=None, name=None):
+    def __init__(self, origin=None, direction=None, pipelines=None, parent=None, name=None):
 
-        self._origin = Point3D(0, 0, 0)
-        self._direction = Vector3D(1, 0, 0)
         pipelines = pipelines or [SpectralRadiancePipeline0D(accumulate=False)]
 
         super().__init__(pipelines=pipelines, parent=parent, name=name)
 
-        self.origin = origin
-        self.direction = direction
+        if origin is not None:
+            self.origin = origin
+
+        if direction is not None:
+            self.direction = direction


### PR DESCRIPTION
Inconsistency could be achieved if the transform was changed directly
without changing origin and direction throught setters.

origin and direction getters calculate values of origin and direction
from transform, values are not kept in _origin/_direction.

related to issue #322 