### PR TITLE
Use isotope wavelengths instead of element ones when converting from photons/s to Watts in PECs for isotopes

### DIFF
--- a/cherab/openadas/openadas.py
+++ b/cherab/openadas/openadas.py
@@ -238,7 +238,7 @@ class OpenADAS(AtomicData):
                 return NullBeamEmissionPEC()
             raise
 
-        wavelength = self.wavelength(beam_ion, charge, transition)
+        wavelength = self.wavelength(beam_ion, 0, transition)
 
         # load and interpolate data
         return BeamEmissionPEC(data, wavelength, extrapolate=self._permit_extrapolation)

--- a/cherab/openadas/openadas.py
+++ b/cherab/openadas/openadas.py
@@ -154,7 +154,7 @@ class OpenADAS(AtomicData):
             raise
 
         # obtain isotope's rest wavelength for a given transition
-        # the wavelength is used ot convert the PEC from photons/s/m3 to Watts/m3
+        # the wavelength is used ot convert the PEC from photons/s/m3 to W/m3
         wavelength = self.wavelength(receiver_ion, receiver_charge - 1, transition)
 
         # load and interpolate the relevant transition data from each file
@@ -249,7 +249,7 @@ class OpenADAS(AtomicData):
             raise
 
         # obtain isotope's rest wavelength for a given transition
-        # the wavelength is used ot convert the PEC from photons/s/m3 to Watts/m3
+        # the wavelength is used ot convert the PEC from photons/s/m3 to W/m3
         wavelength = self.wavelength(beam_ion, 0, transition)
 
         # load and interpolate data
@@ -278,7 +278,7 @@ class OpenADAS(AtomicData):
             raise
 
         # obtain isotope's rest wavelength for a given transition
-        # the wavelength is used ot convert the PEC from photons/s/m3 to Watts/m3
+        # the wavelength is used ot convert the PEC from photons/s/m3 to W/m3
         wavelength = self.wavelength(ion, charge, transition)
 
         return ImpactExcitationPEC(wavelength, data, extrapolate=self._permit_extrapolation)
@@ -306,7 +306,7 @@ class OpenADAS(AtomicData):
             raise
 
         # obtain isotope's rest wavelength for a given transition
-        # the wavelength is used ot convert the PEC from photons/s/m3 to Watts/m3
+        # the wavelength is used ot convert the PEC from photons/s/m3 to W/m3
         wavelength = self.wavelength(ion, charge, transition)
 
         return RecombinationPEC(wavelength, data, extrapolate=self._permit_extrapolation)

--- a/cherab/openadas/openadas.py
+++ b/cherab/openadas/openadas.py
@@ -72,10 +72,12 @@ class OpenADAS(AtomicData):
 
     def ionisation_rate(self, ion, charge):
 
+        # extract element from isotope because there are no isotope rates in ADAS
         if isinstance(ion, Isotope):
             ion = ion.element
 
         try:
+            # read ionisation rate from json file in the repository
             data = repository.get_ionisation_rate(ion, charge, repository_path=self._data_path)
 
         except RuntimeError:
@@ -87,10 +89,12 @@ class OpenADAS(AtomicData):
 
     def recombination_rate(self, ion, charge):
 
+        # extract element from isotope because there are no isotope rates in ADAS
         if isinstance(ion, Isotope):
             ion = ion.element
 
         try:
+            # read recombination rate from json file in the repository
             data = repository.get_recombination_rate(ion, charge, repository_path=self._data_path)
 
         except RuntimeError:
@@ -102,6 +106,7 @@ class OpenADAS(AtomicData):
 
     def thermal_cx_rate(self, donor_element, donor_charge, receiver_element, receiver_charge):
 
+        # extract elements from isotopes because there are no isotope rates in ADAS
         if isinstance(donor_element, Isotope):
             donor_element = donor_element.element
 
@@ -109,6 +114,7 @@ class OpenADAS(AtomicData):
             receiver_element = receiver_element.element
 
         try:
+            # read thermal CX rate from json file in the repository
             data = repository.get_thermal_cx_rate(donor_element, donor_charge,
                                                   receiver_element, receiver_charge,
                                                   repository_path=self._data_path)
@@ -130,14 +136,15 @@ class OpenADAS(AtomicData):
         :return:
         """
 
-        # extract element from isotope
+        # extract element from donor isotope because there are no isotope rates in ADAS
         if isinstance(donor_ion, Isotope):
             donor_ion = donor_ion.element
 
+        # extract element from receiver isotope, but keep the receiver isotope for the wavelength
         receiver_ion_element = receiver_ion.element if isinstance(receiver_ion, Isotope) else receiver_ion
 
         try:
-            # read data
+            # read element CX rate from json file in the repository
             data = repository.get_beam_cx_rates(donor_ion, receiver_ion_element, receiver_charge, transition,
                                                 repository_path=self._data_path)
 
@@ -146,6 +153,8 @@ class OpenADAS(AtomicData):
                 return [NullBeamCXPEC()]
             raise
 
+        # obtain isotope's rest wavelength for a given transition
+        # the wavelength is used ot convert the PEC from photons/s/m3 to Watts/m3
         wavelength = self.wavelength(receiver_ion, receiver_charge - 1, transition)
 
         # load and interpolate the relevant transition data from each file
@@ -163,7 +172,7 @@ class OpenADAS(AtomicData):
         :return:
         """
 
-        # extract element from isotope
+        # extract elements from isotopes because there are no isotope rates in ADAS
         if isinstance(beam_ion, Isotope):
             beam_ion = beam_ion.element
 
@@ -171,7 +180,7 @@ class OpenADAS(AtomicData):
             plasma_ion = plasma_ion.element
 
         try:
-            # locate data file
+            # read beam stopping rate from json file in the repository
             data = repository.get_beam_stopping_rate(beam_ion, plasma_ion, charge, repository_path=self._data_path)
 
         except RuntimeError:
@@ -192,7 +201,7 @@ class OpenADAS(AtomicData):
         :return:
         """
 
-        # extract element from isotope
+        # extract elements from isotopes because there are no isotope rates in ADAS
         if isinstance(beam_ion, Isotope):
             beam_ion = beam_ion.element
 
@@ -200,7 +209,7 @@ class OpenADAS(AtomicData):
             plasma_ion = plasma_ion.element
 
         try:
-            # locate data file
+            # read beam population rate from json file in the repository
             data = repository.get_beam_population_rate(beam_ion, metastable, plasma_ion, charge,
                                                        repository_path=self._data_path)
 
@@ -222,14 +231,15 @@ class OpenADAS(AtomicData):
         :return:
         """
 
-        # extract element from isotope
+        # extract element from beam isotope, but keep the beam isotope for the wavelength
         beam_ion_element = beam_ion.element if isinstance(beam_ion, Isotope) else beam_ion
 
+        # extract element from plasma isotope because there are no isotope rates in ADAS
         if isinstance(plasma_ion, Isotope):
             plasma_ion = plasma_ion.element
 
         try:
-            # locate data file
+            # read beam emission PEC from json file in the repository
             data = repository.get_beam_emission_rate(beam_ion_element, plasma_ion, charge, transition,
                                                      repository_path=self._data_path)
 
@@ -238,6 +248,8 @@ class OpenADAS(AtomicData):
                 return NullBeamEmissionPEC()
             raise
 
+        # obtain isotope's rest wavelength for a given transition
+        # the wavelength is used ot convert the PEC from photons/s/m3 to Watts/m3
         wavelength = self.wavelength(beam_ion, 0, transition)
 
         # load and interpolate data
@@ -252,9 +264,12 @@ class OpenADAS(AtomicData):
         :return:
         """
 
+        # extract element from isotope because there are no isotope rates in ADAS
+        # keep the isotope for the wavelength
         ion_element = ion.element if isinstance(ion, Isotope) else ion
 
         try:
+            # read electron impact excitation PEC from json file in the repository
             data = repository.get_pec_excitation_rate(ion_element, charge, transition, repository_path=self._data_path)
 
         except RuntimeError:
@@ -262,6 +277,8 @@ class OpenADAS(AtomicData):
                 return NullImpactExcitationPEC()
             raise
 
+        # obtain isotope's rest wavelength for a given transition
+        # the wavelength is used ot convert the PEC from photons/s/m3 to Watts/m3
         wavelength = self.wavelength(ion, charge, transition)
 
         return ImpactExcitationPEC(wavelength, data, extrapolate=self._permit_extrapolation)
@@ -275,9 +292,12 @@ class OpenADAS(AtomicData):
         :return:
         """
 
+        # extract element from isotope because there are no isotope rates in ADAS
+        # keep the isotope for the wavelength
         ion_element = ion.element if isinstance(ion, Isotope) else ion
 
         try:
+            # read free electron recombination PEC from json file in the repository
             data = repository.get_pec_recombination_rate(ion_element, charge, transition, repository_path=self._data_path)
 
         except (FileNotFoundError, KeyError):
@@ -285,16 +305,20 @@ class OpenADAS(AtomicData):
                 return NullRecombinationPEC()
             raise
 
+        # obtain isotope's rest wavelength for a given transition
+        # the wavelength is used ot convert the PEC from photons/s/m3 to Watts/m3
         wavelength = self.wavelength(ion, charge, transition)
 
         return RecombinationPEC(wavelength, data, extrapolate=self._permit_extrapolation)
 
     def line_radiated_power_rate(self, ion, charge):
 
+        # extract element from isotope because there are no isotope rates in ADAS
         if isinstance(ion, Isotope):
             ion = ion.element
 
         try:
+            # read total line radiated power rate from json file in the repository
             data = repository.get_line_radiated_power_rate(ion, charge, repository_path=self._data_path)
 
         except RuntimeError:
@@ -306,10 +330,12 @@ class OpenADAS(AtomicData):
 
     def continuum_radiated_power_rate(self, ion, charge):
 
+        # extract element from isotope because there are no isotope rates in ADAS
         if isinstance(ion, Isotope):
             ion = ion.element
 
         try:
+            # read continuum radiated power rate from json file in the repository
             data = repository.get_continuum_radiated_power_rate(ion, charge, repository_path=self._data_path)
 
         except RuntimeError:
@@ -321,10 +347,12 @@ class OpenADAS(AtomicData):
 
     def cx_radiated_power_rate(self, ion, charge):
 
+        # extract element from isotope because there are no isotope rates in ADAS
         if isinstance(ion, Isotope):
             ion = ion.element
 
         try:
+            # read CX radiated power rate from json file in the repository
             data = repository.get_cx_radiated_power_rate(ion, charge, repository_path=self._data_path)
 
         except RuntimeError:

--- a/cherab/openadas/rates/beam.pxd
+++ b/cherab/openadas/rates/beam.pxd
@@ -55,6 +55,7 @@ cdef class NullBeamPopulationRate(CoreBeamPopulationRate):
 cdef class BeamEmissionPEC(CoreBeamEmissionPEC):
 
     cdef readonly:
+        double wavelength
         dict raw_data
         Function2D _npl_eb
         Function1D _tp

--- a/cherab/openadas/rates/beam.pyx
+++ b/cherab/openadas/rates/beam.pyx
@@ -163,6 +163,7 @@ cdef class BeamEmissionPEC(CoreBeamEmissionPEC):
     @cython.cdivision(True)
     def __init__(self, dict data, double wavelength, bint extrapolate=False):
 
+        self.wavelength = wavelength
         self.raw_data = data
 
         # unpack


### PR DESCRIPTION
This PR fixes #327 by replacing `repository.get_wavelength(ion.element, charge, transition)` calls with `self.wavelength(ion, charge, transition)` calls in `OpenADAS.*_pec()` functions.