### PR TITLE
Perform checks for beam, plasma and atomic data separately in beam and plasma models to generate accurate error messages.

### DIFF
--- a/cherab/core/model/beam/charge_exchange.pyx
+++ b/cherab/core/model/beam/charge_exchange.pyx
@@ -270,9 +270,12 @@ cdef class BeamCXLine(BeamModel):
             BeamPopulationRate coeff
 
         # sanity checks
-        if self._beam is None or self._plasma is None or self._atomic_data is None:
+        if self._beam is None:
             raise RuntimeError("The emission model is not connected to a beam object.")
-
+        if self._plasma is None:
+            raise RuntimeError("The emission model is not connected to a plasma object.")
+        if self._atomic_data is None:
+            raise RuntimeError("The emission model is not connected to an atomic data source.")
         if self._line is None:
             raise RuntimeError("The emission line has not been set.")
 

--- a/cherab/core/model/plasma/impact_excitation.pyx
+++ b/cherab/core/model/plasma/impact_excitation.pyx
@@ -77,8 +77,10 @@ cdef class ExcitationLine(PlasmaModel):
     cdef int _populate_cache(self) except -1:
 
         # sanity checks
-        if self._plasma is None or self._atomic_data is None:
+        if self._plasma is None:
             raise RuntimeError("The emission model is not connected to a plasma object.")
+        if self._atomic_data is None:
+            raise RuntimeError("The emission model is not connected to an atomic data source.")
 
         if self._line is None:
             raise RuntimeError("The emission line has not been set.")

--- a/cherab/core/model/plasma/recombination.pyx
+++ b/cherab/core/model/plasma/recombination.pyx
@@ -77,8 +77,10 @@ cdef class RecombinationLine(PlasmaModel):
     cdef int _populate_cache(self) except -1:
 
         # sanity checks
-        if self._plasma is None or self._atomic_data is None:
+        if self._plasma is None:
             raise RuntimeError("The emission model is not connected to a plasma object.")
+        if self._atomic_data is None:
+            raise RuntimeError("The emission model is not connected to an atomic data source.")
 
         if self._line is None:
             raise RuntimeError("The emission line has not been set.")

--- a/cherab/core/model/plasma/total_radiated_power.pyx
+++ b/cherab/core/model/plasma/total_radiated_power.pyx
@@ -77,8 +77,10 @@ cdef class TotalRadiatedPower(PlasmaModel):
     cdef int _populate_cache(self) except -1:
 
         # sanity checks
-        if self._plasma is None or self._atomic_data is None:
+        if self._plasma is None:
             raise RuntimeError("The emission model is not connected to a plasma object.")
+        if self._atomic_data is None:
+            raise RuntimeError("The emission model is not connected to an atomic data source.")
 
         # cache line radiation species and rate
         self._plt_rate = self._atomic_data.line_radiated_power_rate(self._element, self._charge)


### PR DESCRIPTION
This fixes #331.