### PR TITLE
Improve the docstrings in OpenADAS class.

### DIFF
--- a/cherab/openadas/openadas.py
+++ b/cherab/openadas/openadas.py
@@ -56,6 +56,8 @@ class OpenADAS(AtomicData):
 
     def wavelength(self, ion, charge, transition):
         """
+        Spectral line wavelength for a given transition.
+
         :param ion: Element object defining the ion type.
         :param charge: Charge state of the ion.
         :param transition: Tuple containing (initial level, final level)
@@ -71,6 +73,16 @@ class OpenADAS(AtomicData):
         return repository.get_wavelength(ion, charge, transition, repository_path=self._data_path)
 
     def ionisation_rate(self, ion, charge):
+        """
+        Electron impact ionisation rate for a given species.
+
+        Open-ADAS data is interpolated with cubic spline in log-log space.
+        Nearest neighbour extrapolation is used when permit_extrapolation is True.
+
+        :param ion: Element object defining the ion type.
+        :param charge: Charge state of the ion.
+        :return: Ionisation rate in m^3/s as a function of electron density and temperature.
+        """
 
         # extract element from isotope because there are no isotope rates in ADAS
         if isinstance(ion, Isotope):
@@ -88,6 +100,16 @@ class OpenADAS(AtomicData):
         return IonisationRate(data, extrapolate=self._permit_extrapolation)
 
     def recombination_rate(self, ion, charge):
+        """
+        Recombination rate for a given species.
+
+        Open-ADAS data is interpolated with cubic spline in log-log space.
+        Nearest neighbour extrapolation is used when permit_extrapolation is True.
+
+        :param ion: Element object defining the ion type.
+        :param charge: Charge state of the ion.
+        :return: Recombination rate in m^3/s as a function of electron density and temperature.
+        """
 
         # extract element from isotope because there are no isotope rates in ADAS
         if isinstance(ion, Isotope):
@@ -105,6 +127,19 @@ class OpenADAS(AtomicData):
         return RecombinationRate(data, extrapolate=self._permit_extrapolation)
 
     def thermal_cx_rate(self, donor_element, donor_charge, receiver_element, receiver_charge):
+        """
+        Thermal charge exchange effective rate coefficient for a given donor and receiver species.
+
+        Open-ADAS data is interpolated with cubic spline in log-log space.
+        Linear extrapolation is used when permit_extrapolation is True.
+
+        :param donor_element: Element object defining the donor ion type.
+        :param donor_charge: Charge state of the donor ion.
+        :param receiver_element: Element object defining the receiver ion type.
+        :param receiver_charge: Charge state of the receiver ion.
+        :return: Thermal charge exchange rate in m^3/s as a function of electron density and
+                 temperature.
+        """
 
         # extract elements from isotopes because there are no isotope rates in ADAS
         if isinstance(donor_element, Isotope):
@@ -128,12 +163,23 @@ class OpenADAS(AtomicData):
 
     def beam_cx_pec(self, donor_ion, receiver_ion, receiver_charge, transition):
         """
+        Effective charge exchange photon emission coefficient for a given donor (beam)
+        and receiver (plasma) species and a given transition.
 
-        :param donor_ion:
-        :param receiver_ion:
-        :param receiver_charge:
-        :param transition:
-        :return:
+        The data for "qeb" is interpolated with a cubic spline in log-log space.
+        The data for "qti", "qni", "qz" and "qb" are interpolated with a cubic spline
+        in linear space.
+        Quadratic extrapolation is used for "qeb" and nearest neighbour extrapolation is used for
+        "qti", "qni", "qz" and "qb" when permit_extrapolation is True.
+
+
+        :param donor_ion: Element object defining the donor ion type.
+        :param receiver_ion: Element object defining the receiver ion type.
+        :param receiver_charge: Charge state of the receiver ion.
+        :param transition: Tuple containing (initial level, final level) of the receiver species.
+        :return: Charge exchange photon emission coefficient in W.m^3 as a function of
+                 interaction energy, receiver ion temperature, receiver ion density,
+                 plasma Z-effective, magnetic field magnitude.
         """
 
         # extract element from donor isotope because there are no isotope rates in ADAS
@@ -165,11 +211,17 @@ class OpenADAS(AtomicData):
 
     def beam_stopping_rate(self, beam_ion, plasma_ion, charge):
         """
+        Beam stopping coefficient for a given beam and target species.
 
-        :param beam_ion:
-        :param plasma_ion:
-        :param charge:
-        :return:
+        Open-ADAS data is interpolated with cubic spline in log-log space.
+        Linear and quadratic extrapolations are used for "sen" and "st" respectively
+        when permit_extrapolation is True.
+
+        :param beam_ion: Element object defining the beam ion type.
+        :param plasma_ion: Element object defining the target ion type.
+        :param charge: Charge state of the target ion.
+        :return: The beam stopping coefficient in m^3.s^-1 as a function of interaction energy,
+                 target equivalent electron density, target temperature.
         """
 
         # extract elements from isotopes because there are no isotope rates in ADAS
@@ -193,12 +245,18 @@ class OpenADAS(AtomicData):
 
     def beam_population_rate(self, beam_ion, metastable, plasma_ion, charge):
         """
+        Beam population coefficient for a given beam and target species.
 
-        :param beam_ion:
-        :param metastable:
-        :param plasma_ion:
-        :param charge:
-        :return:
+        Open-ADAS data is interpolated with cubic spline in log-log space.
+        Linear and quadratic extrapolations are used for "sen" and "st" respectively
+        when permit_extrapolation is True.
+
+        :param beam_ion: Element object defining the beam ion type.
+        :param metastable: The beam ion metastable number.
+        :param plasma_ion: Element object defining the target ion type.
+        :param charge: Charge state of the target ion.
+        :return: The beam population coefficient in dimensionless units as a function of
+                 interaction energy, target equivalent electron density, target temperature.
         """
 
         # extract elements from isotopes because there are no isotope rates in ADAS
@@ -223,12 +281,19 @@ class OpenADAS(AtomicData):
 
     def beam_emission_pec(self, beam_ion, plasma_ion, charge, transition):
         """
+        The beam photon emission coefficient for a given beam and target species
+        and a given transition.
 
-        :param beam_ion:
-        :param plasma_ion:
-        :param charge:
-        :param transition:
-        :return:
+        Open-ADAS data is interpolated with cubic spline in log-log space.
+        Linear and quadratic extrapolations are used for "sen" and "st" respectively
+        when permit_extrapolation is True.
+
+        :param beam_ion: Element object defining the beam ion type.
+        :param plasma_ion: Element object defining the target ion type.
+        :param charge: Charge state of the target ion.
+        :param transition: Tuple containing (initial level, final level) of the beam ion.
+        :return: The beam photon emission coefficient in W.m^3 as a function of
+                 interaction energy, target equivalent electron density, target temperature.
         """
 
         # extract element from beam isotope, but keep the beam isotope for the wavelength
@@ -257,11 +322,16 @@ class OpenADAS(AtomicData):
 
     def impact_excitation_pec(self, ion, charge, transition):
         """
+        Electron impact excitation photon emission coefficient for a given species.
 
-        :param ion:
-        :param charge:
-        :param transition:
-        :return:
+        Open-ADAS data is interpolated with cubic spline in log-log space.
+        Nearest neighbour extrapolation is used when permit_extrapolation is True.
+
+        :param ion: Element object defining the ion type.
+        :param charge: Charge state of the ion.
+        :param transition: Tuple containing (initial level, final level).
+        :return: Impact excitation photon emission coefficient in W.m^3 as a
+                 function of electron density and temperature.
         """
 
         # extract element from isotope because there are no isotope rates in ADAS
@@ -285,11 +355,16 @@ class OpenADAS(AtomicData):
 
     def recombination_pec(self, ion, charge, transition):
         """
+        Recombination photon emission coefficient for a given species.
 
-        :param ion:
-        :param charge:
-        :param transition:
-        :return:
+        Open-ADAS data is interpolated with cubic spline in log-log space.
+        Nearest neighbour extrapolation is used when permit_extrapolation is True.
+
+        :param ion: Element object defining the ion type.
+        :param charge: Charge state of the ion after recombination.
+        :param transition: Tuple containing (initial level, final level).
+        :return: Recombination photon emission coefficient in W.m^3 as a function of electron
+                 density and temperature.
         """
 
         # extract element from isotope because there are no isotope rates in ADAS
@@ -312,6 +387,17 @@ class OpenADAS(AtomicData):
         return RecombinationPEC(wavelength, data, extrapolate=self._permit_extrapolation)
 
     def line_radiated_power_rate(self, ion, charge):
+        """
+        Line radiated power coefficient for a given species.
+
+        Open-ADAS data is interpolated with cubic spline in log-log space.
+        Nearest neighbour extrapolation is used when permit_extrapolation is True.
+
+        :param ion: Element object defining the ion type.
+        :param charge: Charge state of the ion.
+        :return: Line radiated power coefficient in W.m^3 as a function of electron
+                 density and temperature.
+        """
 
         # extract element from isotope because there are no isotope rates in ADAS
         if isinstance(ion, Isotope):
@@ -329,6 +415,17 @@ class OpenADAS(AtomicData):
         return LineRadiationPower(ion, charge, data, extrapolate=self._permit_extrapolation)
 
     def continuum_radiated_power_rate(self, ion, charge):
+        """
+        Recombination continuum radiated power coefficient for a given species.
+
+        Open-ADAS data is interpolated with cubic spline in log-log space.
+        Nearest neighbour extrapolation is used when permit_extrapolation is True.
+
+        :param ion: Element object defining the ion type.
+        :param charge: Charge state of the ion.
+        :return: Continuum radiated power coefficient in W.m^3 as a function
+                 of electron density and temperature.
+        """
 
         # extract element from isotope because there are no isotope rates in ADAS
         if isinstance(ion, Isotope):
@@ -346,6 +443,17 @@ class OpenADAS(AtomicData):
         return ContinuumPower(ion, charge, data, extrapolate=self._permit_extrapolation)
 
     def cx_radiated_power_rate(self, ion, charge):
+        """
+        Charge exchange radiated power coefficient for a given species.
+
+        Open-ADAS data is interpolated with cubic spline in log-log space.
+        Linear extrapolation is used when permit_extrapolation is True.
+
+        :param ion: Element object defining the ion type.
+        :param charge: Charge state of the ion.
+        :return: Charge exchange radiated power coefficient in W.m^3 as a function
+                 of electron density and temperature.
+        """
 
         # extract element from isotope because there are no isotope rates in ADAS
         if isinstance(ion, Isotope):


### PR DESCRIPTION
This PR makes the docstrings in `OpenADAS` class more helpful, in particular adding information about the interpolation and extrapolation methods used for each rate coefficient. The need to add this information was discussed in #304. 