### PR TITLE
make EFITquilibrium class variables public

### DIFF
--- a/cherab/tools/equilibrium/efit.pxd
+++ b/cherab/tools/equilibrium/efit.pxd
@@ -32,18 +32,18 @@ cdef class EFITEquilibrium:
 
 
     cdef:
-        readonly Function2D psi, psi_normalised
-        readonly double psi_axis, psi_lcfs
-        readonly tuple r_range, z_range
-        readonly Point2D magnetic_axis
-        readonly tuple x_points, strike_points
-        readonly VectorFunction2D b_field, toroidal_vector, poloidal_vector, surface_normal
-        readonly Function2D inside_lcfs, inside_limiter
-        readonly Function1D psin_to_r
-        readonly double time
-        readonly np.ndarray lcfs_polygon, limiter_polygon
-        readonly np.ndarray psi_data, r_data, z_data
-        readonly Function1D q
+        public Function2D psi, psi_normalised
+        public double psi_axis, psi_lcfs
+        public tuple r_range, z_range
+        public Point2D magnetic_axis
+        public tuple x_points, strike_points
+        public VectorFunction2D b_field, toroidal_vector, poloidal_vector, surface_normal
+        public Function2D inside_lcfs, inside_limiter
+        public Function1D psin_to_r
+        public double time
+        public np.ndarray lcfs_polygon, limiter_polygon
+        public np.ndarray psi_data, r_data, z_data
+        public Function1D q
         double _b_vacuum_magnitude, _b_vacuum_radius
         Function1D _f_profile
         Function2D _dpsidr, _dpsidz


### PR DESCRIPTION
To inherit EFITquilibrium class and override some members, I change the access right them into public. However member variables must be private in usual, so I think it might be preferable to define them as properties.

Anyway, I just throw PR, and if this is Inappropriate, I will close it immediately.