### PR TITLE
Packaging improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,56 +12,66 @@ for guidance on using the code.
 Installation
 ------------
 
-Cherab is a large code framework consisting of a core package and feature  
-packages. Users will generally install the core package and the specific  
-feature packages they need for their work. For example, users working on the  
-JET tokamak will require the ``cherab-core`` package, and the ``cherab-jet``  
+Cherab is a large code framework consisting of a core package and feature
+packages. Users will generally install the core package and the specific
+feature packages they need for their work. For example, users working on the
+JET tokamak will require the `cherab-core` package, and the `cherab-jet`
 package.
 
-Unless developing new code for a cherab package, most users should clone the 
-master branch. When developing new features for cherab, the development branch 
+Unless developing new code for a cherab package, most users should clone the
+master branch. When developing new features for cherab, the development branch
 should be used as the base.
 
-All cherab packages are standard python packages and basic installation is 
+All cherab packages are standard python packages and basic installation is
 achieved with:
 
 ```
-python setup.py install
+pip install cherab
 ```
 
-This will compile the Cherab cython extensions and install the package. If you 
-don't have administrator access to install the package, add the ``--user`` flag 
+This will compile the Cherab cython extensions and install the package. If you
+don't have administrator access to install the package, add the `--user` flag
 to the above line to install the package under your own user account.
+Alternatively, consider creating a [virtual environment](https://docs.python.org/3/tutorial/venv.html)
+and installing `cherab` in the environment.
 
-When developing cherab it is usually preferred that the packages be installed 
-in "develop" mode:
+When developing cherab it is usually preferred that the packages be installed
+in "editable" mode. Clone this repository and change directory to the root of
+the repository, then run:
 
 ```
-python setup.py develop
+pip install -e .
 ```
 
-This will cause the original installation folder to be added to the 
-site-package path. Modifications to the code will therefore be visible to 
-python next time the code is imported. The ``--user`` flag should be used if 
-you do not have administrative permission for your python installation.
+This will cause the original installation folder to be added to the site-package
+path. Modifications to the code will therefore be visible to python next time
+the code is imported. A virtual environment or the ``--user`` flag should be
+used if you do not have administrative permission for your python installation.
+If you make any changes to Cython files you will need to run `./dev/build.sh` to
+rebuild the relevant files.
 
-As all the Cherab packages are dependent on the ``cherab-core`` package, this 
-package must be installed first. Note that other packages may have their own 
-inter-dependencies, see the specific package documentation for more 
-information.
+As all the Cherab packages are dependent on the ``cherab-core`` package, this
+package must be installed first. Note that other packages may have their own
+inter-dependencies, see the specific package documentation for more information.
+
+Cherab is organised as a namespace package, where each of the submodules is
+installed in the same location as the core package. Any submodules using Cython
+with a build-time dependency on Cherab need to use a Cython version newer than
+3.0a5, due to a [bug](https://github.com/cython/cython/issues/2918) in how
+earlier versions of Cython handle namespaces.
 
 Governance
 ----------
 
-The management of the project is divided into Scientific and Technical Project 
-Management. The Scientific management happens through the normal community 
+The management of the project is divided into Scientific and Technical Project
+Management. The Scientific management happens through the normal community
 routes such as JET and MST1 task force meetings, ITPA meetings, etc.
 
-The Technical Management Committee (TMC) is a smaller subset of the community, 
-being responsible for ensuring the integrity and high code quality of Cherab is 
-maintained. These TMC members would have in-depth knowledge of the code base 
-through a demonstrated history of contributing to the project. The TMC would 
-primarily be responsible for accepting / rejecting merge requests on the basis 
+The Technical Management Committee (TMC) is a smaller subset of the community,
+being responsible for ensuring the integrity and high code quality of Cherab is
+maintained. These TMC members would have in-depth knowledge of the code base
+through a demonstrated history of contributing to the project. The TMC would
+primarily be responsible for accepting / rejecting merge requests on the basis
 of code / physics algorithm quality standards.
 
 
@@ -78,6 +88,6 @@ TMC Members
 
 Citing The Code
 ---------------
-* Dr Carine Giroud, Dr Alex Meakins, Dr Matthew Carr, Dr Alfonso Baciero, & 
-Mr Corentin Bertrand. (2018, March 23). Cherab Spectroscopy Modelling Framework 
+* Dr Carine Giroud, Dr Alex Meakins, Dr Matthew Carr, Dr Alfonso Baciero, &
+Mr Corentin Bertrand. (2018, March 23). Cherab Spectroscopy Modelling Framework
 (Version v0.1.0). Zenodo. http://doi.org/10.5281/zenodo.1206142

--- a/cherab/tools/emitters/radiation_function.pxd
+++ b/cherab/tools/emitters/radiation_function.pxd
@@ -1,0 +1,25 @@
+# Copyright 2016-2022 Euratom
+# Copyright 2016-2022 United Kingdom Atomic Energy Authority
+# Copyright 2016-2022 Centro de Investigaciones Energéticas, Medioambientales y Tecnológicas
+#
+# Licensed under the EUPL, Version 1.1 or – as soon they will be approved by the
+# European Commission - subsequent versions of the EUPL (the "Licence");
+# You may not use this work except in compliance with the Licence.
+# You may obtain a copy of the Licence at:
+#
+# https://joinup.ec.europa.eu/software/page/eupl5
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied.
+#
+# See the Licence for the specific language governing permissions and limitations
+# under the Licence.
+
+from raysect.optical.material.emitter cimport InhomogeneousVolumeEmitter
+from cherab.core.math.function cimport Function3D
+
+
+cdef class RadiationFunction(InhomogeneousVolumeEmitter):
+    cdef:
+        readonly Function3D radiation_function

--- a/cherab/tools/emitters/radiation_function.pyx
+++ b/cherab/tools/emitters/radiation_function.pyx
@@ -1,6 +1,6 @@
-# Copyright 2016-2018 Euratom
-# Copyright 2016-2018 United Kingdom Atomic Energy Authority
-# Copyright 2016-2018 Centro de Investigaciones Energéticas, Medioambientales y Tecnológicas
+# Copyright 2016-2022 Euratom
+# Copyright 2016-2022 United Kingdom Atomic Energy Authority
+# Copyright 2016-2022 Centro de Investigaciones Energéticas, Medioambientales y Tecnológicas
 #
 # Licensed under the EUPL, Version 1.1 or – as soon they will be approved by the
 # European Commission - subsequent versions of the EUPL (the "Licence");
@@ -20,7 +20,7 @@ from raysect.optical cimport Point3D, Vector3D, Spectrum, World, Ray, Primitive,
 from raysect.optical.material.emitter cimport InhomogeneousVolumeEmitter, NumericalIntegrator
 from cherab.core.math.function cimport Function3D, autowrap_function3d
 from libc.math cimport M_PI
-import cython
+cimport cython
 
 
 cdef class RadiationFunction(InhomogeneousVolumeEmitter):
@@ -51,10 +51,6 @@ cdef class RadiationFunction(InhomogeneousVolumeEmitter):
        >>> def rad_function_3d(x, y, z): return 0
        >>> radiation_emitter = RadiationFunction(rad_function_3d)
     """
-
-    cdef:
-        readonly Function3D radiation_function
-
     def __init__(self, radiation_function, step=0.1):
 
         super().__init__(NumericalIntegrator(step=step))
@@ -68,7 +64,7 @@ cdef class RadiationFunction(InhomogeneousVolumeEmitter):
                                      AffineMatrix3D world_to_local, AffineMatrix3D local_to_world):
 
         cdef int index
-        cdef double wvl_range = ray.max_wavelength - ray.min_wavelength
+        cdef double wvl_range = ray.get_max_wavelength() - ray.get_min_wavelength()
         cdef double emission
 
         emission = self.radiation_function.evaluate(point.x, point.y, point.z) / (4 * M_PI * wvl_range)

--- a/docs/source/installation_and_structure.rst
+++ b/docs/source/installation_and_structure.rst
@@ -39,7 +39,7 @@ that Cherab can calculate. This package is strictly managed by the Cherab develo
 require some type of atomic data for their calculations. The base types of reaction rates and
 photon emissivity coefficients are defined in the Core API Module,
 `cherab <https://pypi.org/project/cherab>`_. A default atomic data source module based on
- the `OpenADAS project <http://open.adas.ac.uk/>`_, is included in the package. In future
+the `OpenADAS project <http://open.adas.ac.uk/>`_, is included in the package. In future
 other atomic data sources, such as the ALADDIN database for example, could be made available
 through additional packages.
 
@@ -78,7 +78,9 @@ The easiest way to install Cherab with OpenADAS is using `pip <https://pip.pypa.
 
 This will either install a binary package or build Cherab from source (which may take some time).
 If you don't have administrator access to install the packages, add the ``--user`` flag to the above
-line to install the packages under your own user account.
+line to install the packages under your own user account. Alternatively, consider using a
+`virtual environment <https://docs.python.org/3/tutorial/venv.html>`_ to avoid the risk of
+conflicting versions of packages in your Python environment.
 
 
 Installing from source
@@ -94,17 +96,29 @@ If all the required dependencies are present (cython, numpy, scipy, matplotlib a
 start the Cherab compilation and installation process. If you don't have administrator access to install
 the package, add the ``--user`` flag to the above line to install the package under your own user account.
 
-When developing cherab it is usually preferred that the packages be installed in "develop" mode::
-
-    python setup.py develop
-
-This will cause the original installation folder to be added to the site-package path. Modifications to
-the code will therefore be visible to python next time the code is imported. The ``--user`` flag should be
-used if you do not have administrative permission for your python installation.
-
 As all the Cherab packages are dependent on the core ``cherab`` package, this package must be installed first.
 Note that other packages may have their own inter-dependencies, see the specific package documentation for
 more information.
+
+Installing for development
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When developing cherab it is usually preferred that the packages be installed in "develop" mode.
+Clone the project from the development repository, locate the folder containing setup.py and run::
+
+    pip install -e .
+
+The alternative command if pip is not available is::
+
+    python setup.py develop
+
+Either command will cause the original installation folder to be added to the
+site-package path. Modifications to the code will therefore be visible to python next
+time the code is imported. If you are modifying Cython source files then run
+``./dev/build.sh`` to re-build those files in order for the changes to be visible. A
+virtual environment, or the ``--user`` flag, should be used if you do not have
+administrative permission for your python installation.
+
 
 When developing new features for Cherab, the development branch should be used as the base.
 
@@ -128,9 +142,9 @@ Testing
 ~~~~~~~
 
 A selection of test scripts can be run with the `nose` testing framework. These are routinely
-run on the development version.  Running ``nosetests`` at the terminal in the source directory
+run on the development version.  Running ``./dev/test.sh`` at the terminal in the source directory
 should run all of these tests to completion without errors or failures.
 
-Many of the demos used throughout the Raysect documentation are distributed with the source code in
+Many of the demos used throughout the documentation are distributed with the source code in
 the ``demo`` folder.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,3 @@
 [build-system]
 requires = ["setuptools", "wheel", "numpy>=1.14", "cython>=0.28", "raysect==0.7.1"]
+build-backend="setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy>=1.14", "cython>=0.28", "raysect==0.7.1"]
+requires = ["setuptools", "wheel", "oldest-supported-numpy", "cython>=0.28", "raysect==0.7.1"]
 build-backend="setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -4,18 +4,14 @@ import numpy
 import os
 import os.path as path
 import multiprocessing
+from Cython.Build import cythonize
 
 multiprocessing.set_start_method('fork')
 
-use_cython = True
 force = False
 profile = False
 line_profile = False
 install_rates = False
-
-if "--skip-cython" in sys.argv:
-    use_cython = False
-    del sys.argv[sys.argv.index("--skip-cython")]
 
 if "--force" in sys.argv:
     force = True
@@ -43,57 +39,34 @@ if line_profile:
     compilation_args.append("-DCYTHON_TRACE=1")
     compilation_args.append("-DCYTHON_TRACE_NOGIL=1")
     cython_directives["linetrace"] = True
+if profile:
+    cython_directives["profile"] = True
 
-if use_cython:
 
-    from Cython.Build import cythonize
+extensions = []
+for package in source_paths:
+    for root, dirs, files in os.walk(path.join(setup_path, package)):
+        for file in files:
+            if path.splitext(file)[1] == ".pyx":
+                pyx_file = path.relpath(path.join(root, file), setup_path)
+                module = path.splitext(pyx_file)[0].replace("/", ".")
+                extensions.append(
+                    Extension(
+                        module,
+                        [pyx_file],
+                        include_dirs=compilation_includes,
+                        extra_compile_args=compilation_args,
+                    ),
+                )
 
-    # build .pyx extension list
-    extensions = []
-    for package in source_paths:
-        for root, dirs, files in os.walk(path.join(setup_path, package)):
-            for file in files:
-                if path.splitext(file)[1] == ".pyx":
-                    pyx_file = path.relpath(path.join(root, file), setup_path)
-                    module = path.splitext(pyx_file)[0].replace("/", ".")
-                    extensions.append(
-                        Extension(
-                            module,
-                            [pyx_file],
-                            include_dirs=compilation_includes,
-                            extra_compile_args=compilation_args,
-                        ),
-                    )
 
-    if profile:
-        cython_directives["profile"] = True
-
-    # generate .c files from .pyx
-    extensions = cythonize(
-        extensions,
-        nthreads=multiprocessing.cpu_count(),
-        force=force,
-        compiler_directives=cython_directives,
-    )
-
-else:
-
-    # build .c extension list
-    extensions = []
-    for package in source_paths:
-        for root, dirs, files in os.walk(path.join(setup_path, package)):
-            for file in files:
-                if path.splitext(file)[1] == ".c":
-                    c_file = path.relpath(path.join(root, file), setup_path)
-                    module = path.splitext(c_file)[0].replace("/", ".")
-                    extensions.append(
-                        Extension(
-                            module,
-                            [c_file],
-                            include_dirs=compilation_includes,
-                            extra_compile_args=compilation_args,
-                        ),
-                    )
+# generate .c files from .pyx
+extensions = cythonize(
+    extensions,
+    nthreads=multiprocessing.cpu_count(),
+    force=force,
+    compiler_directives=cython_directives,
+)
 
 # parse the package version number
 with open(path.join(path.dirname(__file__), "cherab/core/VERSION")) as version_file:
@@ -131,7 +104,6 @@ setup(
         "scipy",
         "matplotlib",
         "raysect==0.7.1",
-        "cython>=0.28",
     ],
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
A few changes here to make installation of Cherab more robust and more accessible for end users. Recent improvements in Python packaging (PEP517, PEP518) mean we can strip out some of the workarounds which were historically required to install the package, and follow modern best practices.

* Update README and docs to recommend using pip rather than calling setup.py directly, as the latter is deprecated.
* Exploid PEP518 and PEP517 to specify Cython as a build dependency instead of a runtime dependency.
* Remove logic in setup.py to behave differently if Cython is not available.

PEP517/PEP518 support in pip is available as early as version 10.0 back in early 2018, so I think it's pretty safe to assume new installations of Cherab will be in environments where this is supported.