### PR TITLE
Fix f_profile definition in EFITEquilibrium docstring and changelog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Release 1.4.0 (TBD)
 -------------------
 
 New:
-* Make f_profile (toroidal flux) a read-only attribute of EFITEquilibrium. (#355)
+* Make f_profile (current flux) a read-only attribute of EFITEquilibrium. (#355)
 
 Release 1.3.0 (8 Dec 2021)
 --------------------------

--- a/cherab/tools/equilibrium/efit.pyx
+++ b/cherab/tools/equilibrium/efit.pyx
@@ -73,7 +73,7 @@ cdef class EFITEquilibrium:
 
     :ivar Function2D psi: The poloidal flux in the r-z plane, :math:`\psi(r,z)`.
     :ivar Function2D psi_normalised: The normalised poloidal flux in the r-z plane, :math:`\psi_n(r,z)`.
-    :ivar Function1D f_profile: The toroidal flux at the specified normalised poloidal flux, :math:`F(\psi_n)`.
+    :ivar Function1D f_profile: The current flux at the specified normalised poloidal flux, :math:`F(\psi_n)`.
     :ivar Function1D q: The safety factor :math:`q` at the specified normalised poloidal flux, :math:`q(\psi_n)`.
     :ivar VectorFunction2D b_field: A 2D function that returns the magnetic field vector at the specified
       point in the r-z plane, :math:`B(r, z)`.


### PR DESCRIPTION
This is a fix for `f_profile` definition incorrectly specified in #355.