### PR TITLE
Enable testing of SART OpenCL inversion routines with POCL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,9 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Python dependencies
-      run: python -m pip install cython>=0.28 numpy==${{ matrix.numpy-version }} scipy matplotlib
+      run: python -m pip install cython>=0.28 numpy==${{ matrix.numpy-version }} scipy matplotlib pyopencl[pocl]
+    - name: Work around PyOpenCL issue 537
+      run: echo OCL_ICD_VENDORS=$(python -c 'import os, pyopencl; print(os.path.join(*pyopencl.__path__, ".libs"))') >> $GITHUB_ENV
     - name: Install Raysect from pypi
       run: pip install raysect
     - name: Build cherab


### PR DESCRIPTION
Currently the tests for the OpenCL SART solvers are skipped because they require an OpenCL driver. This PR configures the tests to use the POCL CPU-only driver so we can run the tests through Github Actions.

The tests do output some debugging information from the solvers, which should really be put behind an `if verbose` flag or use a debug-level logger. May be worth fixing before merge.