### PR TITLE
Generomak/core plasma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New:
 * Make f_profile (current flux) a read-only attribute of EFITEquilibrium. (#355)
 * Add group observer class for each of Raysect's 0D observers (#332)
 * Add a demo for observer group handling and plotting
+* Add Generomak core plasma profiles (#360)
 
 Bug Fixes:
 ----------

--- a/cherab/generomak/plasma/__init__.py
+++ b/cherab/generomak/plasma/__init__.py
@@ -1,1 +1,2 @@
 from .plasma import get_edge_distributions, get_edge_interpolators, get_edge_plasma
+from .plasma import get_core_distributions, get_core_plasma

--- a/cherab/generomak/plasma/plasma.py
+++ b/cherab/generomak/plasma/plasma.py
@@ -342,32 +342,32 @@ def get_core_profiles_arguments(**kwargs):
 
     List of core parameters, their meaning and default values
         ne_core: (default 5e19) core electron density
-        ne_convexity: (default 2) (default ) convexity of the electron density profile
-        ne_concavity: (default 4) concavity of the electron density profile
+        ne_convexity: (default 1.09) (default ) convexity of the electron density profile
+        ne_concavity: (default 0.24) concavity of the electron density profile
         te_core core: (default 3e3) electron temperature
-        te_convexity: (default 2) convexity of the electron temperature profile
-        te_concavity: (default 3) concavity of the electron temperature profile
-        nh_core core: (default 5e19) density of H1+
-        nh_convexity: (default 2) convexity of H1+ density profile
-        nh_concavity: (default 4) concavity of H1+ density profile
-        th_core core: (default 2.8e3) H1+ temperature
-        th_convexity: (default 2) convexity of H1+ temperature profile
-        th_concavity: (default 4) concavity of H1+ temperature profile
+        te_convexity: (default 2.35) convexity of the electron temperature profile
+        te_concavity: (default 1.26) concavity of the electron temperature profile
+        nh_core: (default 5e19) density of H1+
+        nh_convexity: (default 1.09) convexity of H1+ density profile
+        nh_concavity: (default 0.24) concavity of H1+ density profile
+        th_core: (default 2.8e3) H1+ temperature
+        th_convexity: (default 1) convexity of H1+ temperature profile
+        th_concavity: (default 0.82) concavity of H1+ temperature profile
         th0_fraction: (default 0.8) H0 temperature factor
-        nh0_decay decay: (default 10) rate of H0 density profile
-        timp_core core: (default 2.7e3) impurity density
-        timp_convexity: (default 2) convexity of impurity temperature profile
-        timp_concavity: (default 4) concavity of impurity temperature profile
-        nimp_core core: (default 5e17) impurity density
-        nimp_convexity: (default 2) convexity of impurity density profile
-        nimp_concavity: (default 4) concavity of impurity density profile
-        nimp_decay: (default 8) decay rate of impurity density profile (except bare nuclei)
-        vtor_core: (default 1e5) toroidal rotation velocity at the edge m/s
-        vtor_edge: (default 1e4) core toroidal rotation velocity m/s
+        nh0_decay decay: (default 20) rate of H0 density profile
+        timp_core: (default 2.7e3) core impurity temperature
+        timp_convexity: (default 1) convexity of impurity temperature profile
+        timp_concavity: (default 0.82) concavity of impurity temperature profile
+        nimp_core: (default 5e17) impurity density
+        nimp_convexity: (default 1.09) convexity of impurity density profile
+        nimp_concavity: (default 0.24) concavity of impurity density profile
+        nimp_decay: (default 30) decay rate of impurity density profile (except bare nuclei)
+        vtor_core: (default 1e5) toroidal rotation velocity m/s
+        vtor_edge: (default 1e4) toroidal rotation velocity at the edge m/s
         vtor_convexity: (default 2) convexity of the toroidal rotation profile
         vtor_concavity: (default 4) concavity of the toroidal rotation profile
         vpol_lcfs: (default 2e4) Bulk poloidal rotation velocity in m/s
-        vpol_decay: (default 0.08)
+        vpol_decay: (default 0.08) Decay rate of poloidal rotation velocity
 
     :return: dictionary of profile arguments
     """

--- a/cherab/generomak/plasma/plasma.py
+++ b/cherab/generomak/plasma/plasma.py
@@ -340,7 +340,7 @@ def get_core_profiles_arguments(**kwargs):
     If there is a match, the default value is overwritten by th passed value, the default value is kept
     otherwise.
 
-    List of core parameters, their meanint and default values
+    List of core parameters, their meaning and default values
         ne_core: (default 5e19) core electron density
         ne_convexity: (default 2) (default ) convexity of the electron density profile
         ne_concavity: (default 4) concavity of the electron density profile
@@ -371,18 +371,18 @@ def get_core_profiles_arguments(**kwargs):
 
     :return: dictionary of profile arguments
     """
-
-    core_args = {"ne_core": 5e19, "ne_convexity": 2,
-                         "ne_concavity": 4, "te_core": 3e3,
-                         "te_convexity": 2, "te_concavity": 3,
-                         "nh_core": 5e19, "nh_convexity": 2,
-                         "nh_concavity": 4, "th_core": 2.8e3,
-                         "th_convexity": 2, "th_concavity": 4,
-                         "th0_fraction": 0.8, "nh0_decay": 10,
-                         "timp_core": 2.7e3, "timp_convexity": 2,
-                         "timp_concavity": 4, "nimp_core": 5e17,
-                         "nimp_convexity": 2, "nimp_concavity": 4,
-                         "nimp_decay": 8,
+    
+    core_args = {"ne_core": 5e19, "ne_convexity": 1.09,
+                         "ne_concavity": 0.24, "te_core": 3e3,
+                         "te_convexity": 2.35, "te_concavity": 1.26,
+                         "nh_core": 5e19, "nh_convexity": 1.09,
+                         "nh_concavity": 0.24, "th_core": 2.8e3,
+                         "th_convexity": 1, "th_concavity": 0.82,
+                         "th0_fraction": 0.8, "nh0_decay": 20,
+                         "timp_core": 2.7e3, "timp_convexity": 1,
+                         "timp_concavity": 0.82, "nimp_core": 5e17,
+                         "nimp_convexity": 1.09, "nimp_concavity": 0.24,
+                         "nimp_decay": 30,
                          "vtor_core": 1e5, "vtor_edge": 1e4,
                          "vtor_convexity": 2, "vtor_concavity": 4,
                          "vpol_lcfs": 2e4, "vpol_decay": 0.08}

--- a/cherab/generomak/plasma/plasma.py
+++ b/cherab/generomak/plasma/plasma.py
@@ -37,6 +37,7 @@ from cherab.openadas import OpenADAS
 
 from cherab.generomak.equilibrium import load_equilibrium
 
+
 def load_edge_profiles():
     """
     Loads Generomak edge plasma profiles
@@ -88,6 +89,7 @@ def load_edge_profiles():
 
     return edge_data.freeze()
 
+
 def get_edge_interpolators():
     """
     Provides Generomak edge profiles 2d interpolator
@@ -118,8 +120,8 @@ def get_edge_interpolators():
             mesh_interp["composition"][elem_name][stage]["density"] = n
             mesh_interp["composition"][elem_name][stage]["element"] = stage_data["element"]
 
-
     return mesh_interp.freeze()
+
 
 def get_edge_distributions():
     """
@@ -156,6 +158,7 @@ def get_edge_distributions():
 
     return dists.freeze()
 
+
 def get_edge_plasma(atomic_data=None, parent=None, name="Generomak edge plasma"):
     """
     Provides Generomak Edge plasma.
@@ -171,8 +174,8 @@ def get_edge_plasma(atomic_data=None, parent=None, name="Generomak edge plasma")
 
     # create or check atomic_data
     if atomic_data is not None:
-     if not isinstance(atomic_data, AtomicData):
-         raise ValueError("atomic_data has to be of type AtomicData")
+        if not isinstance(atomic_data, AtomicData):
+            raise ValueError("atomic_data has to be of type AtomicData")
     else:
         atomic_data = OpenADAS()
 
@@ -187,7 +190,7 @@ def get_edge_plasma(atomic_data=None, parent=None, name="Generomak edge plasma")
     z_range = (vertex_coords[:, 1].min(), vertex_coords[:, 1].max())
     plasma_height = z_range[1] - z_range[0]
 
-    padding = 1e-3 #enlarge for safety
+    padding = 1e-3  # enlarge for safety
 
     outer_column = Cylinder(radius=r_range[1], height=plasma_height)
     inner_column = Cylinder(radius=r_range[0], height=plasma_height + 2 * padding)
@@ -218,6 +221,7 @@ def get_edge_plasma(atomic_data=None, parent=None, name="Generomak edge plasma")
 
     return plasma
 
+
 def get_double_parabola(v_min, v_max, convexity, concavity, xmin=0, xmax=1):
     """
     Returns a 1d double-quadratic Function1D
@@ -242,12 +246,13 @@ def get_double_parabola(v_min, v_max, convexity, concavity, xmin=0, xmax=1):
     """
 
     x = Arg1D() #the free parameter
-    
+
     # funciton for the normalised free variable
     x_norm = ClampInput1D((x - xmin) / (xmax - xmin), 0, 1)
 
     # profile function
     return (v_max - v_min) * ((1 - ((1 - x_norm) ** convexity)) ** concavity) + v_min
+
 
 def get_exponential_growth(initial_value, growth_rate, initial_position=1):
     """
@@ -269,9 +274,10 @@ def get_exponential_growth(initial_value, growth_rate, initial_position=1):
     x = Arg1D() #the free parameter
     return initial_value * Exp1D((x - initial_position) * growth_rate)
 
+
 def get_maxwellian_distribution(equilibrium, f1d_density, f1d_temperature, f1d_vtor, f1d_vpol, f1d_vnorm, rest_mass):
     """ Returns Maxwellian distribution for equilibrium mapped 1d profiles
-    
+
     :param equilibrium: Instance of EFITEquilibrium
     :param f1d_density: Function1D describing density profile.
     :param f1d_temperature: Function1D describing temperature profile.
@@ -287,9 +293,10 @@ def get_maxwellian_distribution(equilibrium, f1d_density, f1d_temperature, f1d_v
     f3d_te = equilibrium.map3d(f1d_temperature)
     f3d_ne = equilibrium.map3d(f1d_density)
     f3d_v = equilibrium.map_vector3d(f1d_vtor, f1d_vpol, f1d_vnorm)
-    
+
     # return Maxwellian distribution
     return Maxwellian(f3d_ne, f3d_te, f3d_v, rest_mass)
+
 
 def get_edge_profile_values(r, z, edge_interpolators=None):
     """
@@ -321,8 +328,9 @@ def get_edge_profile_values(r, z, edge_interpolators=None):
                     lcfs_values["composition"][spec][chrg][prop] = val(r, z)
                 else:
                     lcfs_values["composition"][spec][chrg][prop] = val
-    
+
     return lcfs_values.freeze()
+
 
 def get_core_profiles_arguments(**kwargs):
     """
@@ -336,7 +344,7 @@ def get_core_profiles_arguments(**kwargs):
         ne_core: (default 5e19) core electron density
         ne_convexity: (default 2) (default ) convexity of the electron density profile
         ne_concavity: (default 4) concavity of the electron density profile
-        te_core core: (default 3e3) electron temperature 
+        te_core core: (default 3e3) electron temperature
         te_convexity: (default 2) convexity of the electron temperature profile
         te_concavity: (default 3) concavity of the electron temperature profile
         nh_core core: (default 5e19) density of H1+
@@ -360,7 +368,7 @@ def get_core_profiles_arguments(**kwargs):
         vtor_concavity: (default 4) concavity of the toroidal rotation profile
         vpol_lcfs: (default 2e4) Bulk poloidal rotation velocity in m/s
         vpol_decay: (default 0.08)
-    
+
     :return: dictionary of profile arguments
     """
 
@@ -388,6 +396,7 @@ def get_core_profiles_arguments(**kwargs):
 
     return core_args
 
+
 def get_core_profiles_description(lcfs_values=None, core_args=None):
     """
     Returns dictionary of core profile functions and species descriptions
@@ -409,7 +418,7 @@ def get_core_profiles_description(lcfs_values=None, core_args=None):
         r = equilibrium.psin_to_r(1)
         z = 0
         lcfs_values = get_edge_profile_values(r, z)
-    
+
     if core_args is None:
         core_args = get_core_profiles_arguments()
 
@@ -422,7 +431,7 @@ def get_core_profiles_description(lcfs_values=None, core_args=None):
 
     # velocity normal to magnetic surfaces
     f1d_vnorm = Constant1D(0)
-   
+
     # construct dictionary with 1D profile functions
     profiles = RecursiveDict()
 
@@ -479,6 +488,7 @@ def get_core_profiles_description(lcfs_values=None, core_args=None):
 
     return profiles.freeze()
 
+
 def get_core_distributions(profiles=None, equilibrium=None):
     """
     Returns a dictionary of core plasma species Maxwellian distributions.
@@ -492,11 +502,10 @@ def get_core_distributions(profiles=None, equilibrium=None):
     # get core profile data if not passed sa argument
     if profiles is None:
         profiles = get_core_profiles_description()
-    
+
     # load plasma equilibrium if not passed as argument
     if equilibrium is None:
         equilibrium = load_equilibrium()
-
 
     # build a dictionary with Maxwellian distributions
     species = RecursiveDict()
@@ -507,8 +516,9 @@ def get_core_distributions(profiles=None, equilibrium=None):
         for chrg, desc in spec.items():
             rest_mass = atomic_mass * spec_cherab.atomic_weight
             species["composition"][name][chrg] = get_maxwellian_distribution(equilibrium, rest_mass=rest_mass,  **desc)
-        
+
     return species.freeze()
+
 
 def get_core_plasma(distributions=None, atomic_data=None, parent=None, name="Generomak core plasma"):
     """
@@ -522,7 +532,7 @@ def get_core_plasma(distributions=None, atomic_data=None, parent=None, name="Gen
     :param name: name of the plasma node, defaults "Generomak edge plasma"
     :return: populated Plasma object
     """
-    
+
     # load Generomak equilibrium
     equilibrium = load_equilibrium()
 
@@ -543,13 +553,13 @@ def get_core_plasma(distributions=None, atomic_data=None, parent=None, name="Gen
 
     # coordinate transform of the plasma frame
     geometry_transform = translate(0, 0, equilibrium.z_range[0])
-    
+
     # load core distributions if needed
     if distributions is None:
         dists = get_core_distributions()
     else:
         dists = distributions
-    
+
     # create plasma composition list
     plasma_composition = []
     for elem_name, elem_data in dists["composition"].items():
@@ -570,9 +580,10 @@ def get_core_plasma(distributions=None, atomic_data=None, parent=None, name="Gen
 
     return plasma
 
+
 def _get_cherab_element(name):
     """Returns cherab element instance
-    
+
     :param name: Name or label of the element Cherab has to know.
     :return: Cherab element
     """

--- a/cherab/generomak/plasma/plasma.py
+++ b/cherab/generomak/plasma/plasma.py
@@ -275,9 +275,9 @@ def get_maxwellian_distribution(equilibrium, f1d_density, f1d_temperature, f1d_v
     :param equilibrium: Instance of EFITEquilibrium
     :param f1d_density: Function1D describing density profile.
     :param f1d_temperature: Function1D describing temperature profile.
-    :param f1d_f1d_vtor: Function1D describing bulk toroidal rotation velocity profile.
-    :param f1d_f1d_vpol: Function1D describing bulk poloidal rotation velocity profile.
-    :param f1d_vnom: Function1D describing bulk velocity normal to magnetic surfaces.
+    :param f1d_vtor: Function1D describing bulk toroidal rotation velocity profile.
+    :param f1d_vpol: Function1D describing bulk poloidal rotation velocity profile.
+    :param f1d_vnorm: Function1D describing bulk velocity normal to magnetic surfaces.
     :rest_mass: Rest mass of the distribution species.
     :return: Maxwellian distribution
     """
@@ -342,7 +342,7 @@ def get_core_profiles_description(lcfs_values=None, ne_core=5e19, ne_convexity=2
     Returns dictionary of core profile functions and species descriptions
 
     :param lcfs_values: Dictionary of profile values at the separatrix on outer midplane.
-                        The dictionary has to have the same for, mas the one returned by
+                        The dictionary has to have the same format as the one returned by
                         the function get_edge_profile_values. The default value is the
                         dictionary returned by the call get_edge_profile_values for r, z
                         on last closed flux surface on outer midplane.
@@ -351,13 +351,13 @@ def get_core_profiles_description(lcfs_values=None, ne_core=5e19, ne_convexity=2
     :param ne_concavity: concavity of the electron density profile
     :param te_core: core electron temperature 
     :param te_convexity: convexity of the electron temperature profile
-    :param te_concavity: convexity of the electron temperature profile
+    :param te_concavity: concavity of the electron temperature profile
     :param nh_core: core density of H1+
     :param nh_convexity: convexity of H1+ density profile
     :param nh_concavity: concavity of H1+ density profile
     :param th_core: core H1+ temperature
-    :param th_convexity: convexity of H1+ density profile
-    :param th_concavity: convexity of H1+ density profile
+    :param th_convexity: convexity of H1+ temperature profile
+    :param th_concavity: concavity of H1+ temperature profile
     :param th0_fraction: H0 temperature factor
     :param nh0_decay: decay rate of H0 density profile
     :param timp_core: core impurity density
@@ -477,10 +477,10 @@ def get_core_plasma(distributions=None, atomic_data=None, parent=None, name="Gen
     """
     Provides Generomak core plasma.
 
-    :param distributions: A dictionary of plasma distributions. Has to have the same for mas the
+    :param distributions: A dictionary of plasma distributions. Has to have the same format as the
                           dictionary returned by get_core_distributions. The default value
                           is the value returned by the call get_core_distributions().
-    :param atomic_data: Instance of AtomicData, default isOpenADAS()
+    :param atomic_data: Instance of AtomicData, default is OpenADAS()
     :param parent: parent of the plasma node, defaults None
     :param name: name of the plasma node, defaults "Generomak edge plasma"
     :return: populated Plasma object
@@ -491,8 +491,8 @@ def get_core_plasma(distributions=None, atomic_data=None, parent=None, name="Gen
 
     # create or check atomic_data
     if atomic_data is not None:
-     if not isinstance(atomic_data, AtomicData):
-         raise ValueError("atomic_data has to be of type AtomicData")   
+        if not isinstance(atomic_data, AtomicData):
+            raise ValueError("atomic_data has to be of type AtomicData")   
     else:
         atomic_data = OpenADAS()
 
@@ -505,7 +505,7 @@ def get_core_plasma(distributions=None, atomic_data=None, parent=None, name="Gen
     plasma_geometry = Subtract(outer_column, inner_column)
 
     # coordinate transform of the plasma frame
-    geometry_transform = translate(0, 0, -outer_column.height / 2)
+    geometry_transform = translate(0, 0, equilibrium.z_range[0])
     
     # load core distributions if needed
     if distributions is None:

--- a/demos/generomak/plasma/plot_core_profiles.py
+++ b/demos/generomak/plasma/plot_core_profiles.py
@@ -35,7 +35,6 @@ ax_t.set_ylabel("eV")
 # setup density plot
 _, ax_n = plt.subplots()
 ax_n.set_yscale("log")
-ax_n.tick_params(axis='both', which='both', labelsize=20)
 ax_n.set_title("Species Core Density Profiles")
 ax_n.set_xlabel("psin")
 ax_n.set_ylabel("m^-3")

--- a/demos/generomak/plasma/plot_core_profiles.py
+++ b/demos/generomak/plasma/plot_core_profiles.py
@@ -1,0 +1,66 @@
+
+# Copyright 2016-2021 Euratom
+# Copyright 2016-2021 United Kingdom Atomic Energy Authority
+# Copyright 2016-2021 Centro de Investigaciones Energéticas, Medioambientales y Tecnológicas
+#
+# Licensed under the EUPL, Version 1.1 or – as soon they will be approved by the
+# European Commission - subsequent versions of the EUPL (the "Licence");
+# You may not use this work except in compliance with the Licence.
+# You may obtain a copy of the Licence at:
+#
+# https://joinup.ec.europa.eu/software/page/eupl5
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied.
+#
+# See the Licence for the specific language governing permissions and limitations
+# under the Licence.
+
+import numpy as np
+
+import matplotlib.pyplot as plt
+
+from cherab.core.math.samplers import sample1d_points
+from cherab.generomak.plasma.plasma import get_core_profiles_description
+
+profiles = get_core_profiles_description()
+
+# setup temperature plot
+_, ax_t = plt.subplots()
+ax_t.set_title("Species Core Temperature Profiles")
+ax_t.set_xlabel("Psin")
+ax_t.set_ylabel("eV")
+
+# setup density plot
+_, ax_n = plt.subplots()
+ax_n.set_yscale("log")
+ax_n.tick_params(axis='both', which='both', labelsize=20)
+ax_n.set_title("Species Core Density Profiles")
+ax_n.set_xlabel("psin")
+ax_n.set_ylabel("m^-3")
+
+psin = np.linspace(0, 1, 30)
+# add hydrogen curves
+for chrg, desc in profiles["composition"]["hydrogen"].items():
+    vals = sample1d_points(desc["f1d_temperature"], psin)
+    ax_t.plot(psin, vals, label="H{:d}+".format(chrg))
+    vals = sample1d_points(desc["f1d_density"], psin)
+    ax_n.plot(psin, vals, label="H{:d}+".format(chrg))
+
+# add carbon curves
+for chrg, desc in profiles["composition"]["carbon"].items():
+    vals = sample1d_points(desc["f1d_temperature"], psin)
+    ax_t.plot(psin, vals, label="C{:d}+".format(chrg))
+    vals = sample1d_points(desc["f1d_density"], psin)
+    ax_n.plot(psin, vals, label="C{:d}+".format(chrg))
+
+# add electrons
+vals = sample1d_points(profiles["electron"]["f1d_temperature"], psin)
+ax_t.plot(psin, vals, label="electron", ls="dashed")
+vals = sample1d_points(profiles["electron"]["f1d_density"], psin)
+ax_n.plot(psin, vals, label="electron", ls="dashed")
+
+ax_t.legend()
+ax_n.legend(ncol=2)
+plt.show()


### PR DESCRIPTION
This PR adds several functions providing Generomak Core plasma. The plasma profiles take 2 shapes. The first is a double quadratic, which is used for temperatures and some densities (H1+, C6+) and exponential decay for the rest. The 1D profiles are mapped into 3D using the generomak equilibrium, assuming constant values on magnetic surfaces. On default, the edge values of profiles are values of edge profiles on lcfs outer midplane. 

This PR is related to the issue #210 