### PR TITLE
Feature/openadas rates fallback

### DIFF
--- a/cherab/core/math/__init__.pxd
+++ b/cherab/core/math/__init__.pxd
@@ -22,6 +22,7 @@ from cherab.core.math.function cimport *
 from cherab.core.math.interpolators cimport *
 from cherab.core.math.caching cimport *
 from cherab.core.math.clamp cimport *
+from cherab.core.math.fallback cimport *
 from cherab.core.math.mappers cimport *
 from cherab.core.math.mask cimport *
 from cherab.core.math.slice cimport *

--- a/cherab/core/math/__init__.py
+++ b/cherab/core/math/__init__.py
@@ -31,6 +31,7 @@ from .interpolators import Interpolate3DLinear, Interpolate3DCubic
 from .caching import Caching1D, Caching2D, Caching3D
 from .clamp import ClampOutput1D, ClampOutput2D, ClampOutput3D
 from .clamp import ClampInput1D, ClampInput2D, ClampInput3D
+from .fallback import OutofRangeFallback1D, OutofRangeFallback2D, OutofRangeFallback3D
 from .mappers import IsoMapper2D, IsoMapper3D, Swizzle2D, Swizzle3D, AxisymmetricMapper, VectorAxisymmetricMapper
 from .mask import PolygonMask2D
 from .slice import Slice2D, Slice3D

--- a/cherab/core/math/fallback.pxd
+++ b/cherab/core/math/fallback.pxd
@@ -1,0 +1,21 @@
+from cherab.core.math.function cimport Function1D, Function2D, Function3D
+
+
+cdef class OutofRangeFallback1D(Function1D):
+
+    cdef:
+        Function1D _f
+        double _xmin, _xmax, _fallback
+
+cdef class OutofRangeFallback2D(Function2D):
+
+    cdef:
+        Function2D _f
+        double _xmin, _xmax, _ymin, _ymax, _fallback
+
+cdef class OutofRangeFallback3D(Function3D):
+
+    cdef:
+        Function3D _f
+        double _xmin, _xmax, _ymin, _ymax, _zmin, _zmax
+        double _fallback

--- a/cherab/core/math/fallback.pyx
+++ b/cherab/core/math/fallback.pyx
@@ -1,0 +1,156 @@
+from libc.math cimport INFINITY
+
+from cherab.core.math.function cimport autowrap_function1d, autowrap_function2d, autowrap_function3d
+
+cdef class OutofRangeFallback1D(Function1D):
+    """
+    Sets function value outside of (xmin, xmax) interval to a fallback constant.
+
+    Wraps a Function1D and returns constant fallback outside of the specified interval
+    [xmin, xmax]. A single limit can be used.
+
+    :param Function1D f: A 1D function to be wrapped
+    :param double fallback: Function value returned outside [xmin, xmax] interval
+    :param double xmin: Optional, the lower bound of the x interval
+    :param double xmax: Optional, the upper bound of the x interval
+    :return: function or fallback value
+
+    .. code-block:: pycon
+
+        >>> from cherab.core.math import OutofRangeFallback1D
+        >>>
+        >>> def f1d(x): return x
+        >>> fallback = OutofRangeFallback1D(f1d, 333., -10, 10)
+        >>> fallback(1)
+        1
+        >>> fallback(-11)
+        333.
+        >>> fallback(11)
+        333.
+    """
+    def __init__(self,object f, double fallback, double xmin=-INFINITY,
+                 double xmax=INFINITY):
+
+        if xmin >= xmax:
+            raise ValueError("min value has to be smaller then max value")
+
+        self._fallback = fallback
+
+        self._xmin = xmin
+        self._xmax = xmax
+        self._f = autowrap_function1d(f)
+        
+    cdef double evaluate(self, double x) except? -1e999:
+
+        if not self._xmin <= x <= self._xmax:
+            return self._fallback
+        
+        return self._f.evaluate(x)
+
+
+cdef class OutofRangeFallback2D(Function2D):
+    """
+    Sets function value outside of (xmin, xmax) or (ymin, ymax) interval to a fallback constant.
+
+    Wraps a Function2D and returns constant fallback outside of the specified interval
+    [xmin, xmax] or [ymin, ymax]. A single limit can be used.
+
+    :param Function2D f: A 2D function to be wrapped
+    :param double fallback: Function value returned outside [xmin, xmax] or [ymin, ymax] interval
+    :param double xmin: Optional, the lower bound of the x interval
+    :param double xmax: Optional, the upper bound of the x interval
+    :param double ymin: Optional, the lower bound of the y interval
+    :param double ymax: Optional, the upper bound of the y interval
+    :return: function or fallback value
+
+    .. code-block:: pycon
+
+        >>> from cherab.core.math import OutofRangeFallback2D
+        >>>
+        >>> def f2d(x, y): return x + y
+        >>> fallback = OutofRangeFallback1D(f2d, 333., -10, 20, -32, 45)
+        >>> fallback(1, 45)
+        46
+        >>> fallback(-11, 1)
+        333.
+        >>> fallback(1, 46)
+        333.
+    """
+    def __init__(self,object f, double fallback, double xmin=-INFINITY, double xmax=INFINITY,
+                 double ymin=-INFINITY, double ymax=INFINITY):
+
+        if xmin >= xmax or ymin >= ymax:
+            raise ValueError("min value has to be smaller then max value")
+
+        self._fallback = fallback
+
+        self._xmin = xmin
+        self._xmax = xmax
+        self._ymin = ymin
+        self._ymax = ymax
+        self._f = autowrap_function2d(f)
+
+    cdef double evaluate(self, double x, double y) except? -1e999:
+
+        if not self._xmin <= x <= self._xmax or not self._ymin <= y <= self._ymax:
+            return self._fallback
+        
+        return self._f.evaluate(x, y)
+
+cdef class OutofRangeFallback3D(Function3D):
+    """
+    Sets function value outside of (xmin, xmax), (ymin, ymax) or (zmin, zmax) interval
+    to a fallback constant.
+
+    Wraps a Function3D and returns constant fallback outside of the specified interval
+    [xmin, xmax], [ymin, ymax], [zmin, zmax]. A single limit can be used.
+
+    :param Function3D f: A 3D function to be wrapped
+    :param double fallback: Function value returned outside [xmin, xmax], [ymin, ymax]
+      or [zmin, zmax] interval
+    :param double xmin: Optional, the lower bound of the x interval
+    :param double xmax: Optional, the upper bound of the x interval
+    :param double ymin: Optional, the lower bound of the y interval
+    :param double ymax: Optional, the upper bound of the y interval
+    :param double zmin: Optional, the lower bound of the z interval
+    :param double zmax: Optional, the upper bound of the z interval
+    :return: function or fallback value
+
+    .. code-block:: pycon
+
+        >>> from cherab.core.math import OutofRangeFallback3D
+        >>>
+        >>> def f3d(x, y, z): return x + y + z
+        >>> fallback = OutofRangeFallback1D(f3d, 333., -10, 20, -32, 45, 20, 80)
+        >>> fallback(1, 45, 22)
+        68.
+        >>> fallback(-11, 1, 79)
+        333.
+        >>> fallback(1, 46, 10)
+        333.
+    """
+    def __init__(self,object f, double fallback, double xmin=-INFINITY, double xmax=INFINITY,
+                 double ymin=-INFINITY, double ymax=INFINITY,
+                 double zmin=-INFINITY, double zmax=INFINITY):
+
+        if xmin >= xmax or ymin >= ymax or zmin >= zmax:
+            raise ValueError("lower bound value has to be smaller then upper bound value")
+
+        self._fallback = fallback
+
+        self._xmin = xmin
+        self._xmax = xmax
+        self._ymin = ymin
+        self._ymax = ymax
+        self._zmin = zmin
+        self._zmax = zmax
+        self._f = autowrap_function3d(f)
+        
+
+    cdef double evaluate(self, double x, double y, double z) except? -1e999:
+        
+        if not self._xmin <= x <= self._xmax or not self._ymin <= y <= self._ymax or \
+           not self._zmin <= z <= self._zmax:
+           return self._fallback
+
+        return self._f.evaluate(x, y, z)

--- a/cherab/core/math/tests/test_fallback.py
+++ b/cherab/core/math/tests/test_fallback.py
@@ -1,0 +1,150 @@
+import unittest
+
+from cherab.core.math import OutofRangeFallback1D, OutofRangeFallback2D, OutofRangeFallback3D
+
+
+class TestFallbacks(unittest.TestCase):
+
+    def setUp(self):
+        """Initialisation with functions to map."""
+
+        def f1d(x): return x
+        self.function1d = f1d
+        def f2d(x, y): return x + y
+        self.function2d = f2d
+        def f3d(x, y, z): return x + y + z
+        self.function3d = f3d
+
+    def test_fallback1d_init(self):
+
+        OutofRangeFallback1D(self.function1d, 0)
+
+        with self.assertRaises(ValueError):
+            OutofRangeFallback1D(self.function1d, 0, xmin=10, xmax=10)
+            OutofRangeFallback1D(self.function1d, 0, xmin=10, xmax=-10)
+
+    def test_fallback1d(self):
+
+        # test with no limits
+        fb1d_nolim = OutofRangeFallback1D(self.function1d, 0)
+        self.assertEqual(fb1d_nolim(-100), -100., msg="fallback should return input")
+
+        # test bottom limit
+        fb1d_bottomlim = OutofRangeFallback1D(self.function1d, 333, xmin=-10)
+        self.assertEqual(fb1d_bottomlim(-10), -10., msg="fallback should return input")
+        self.assertEqual(fb1d_bottomlim(-1000), 333., msg="fallback should return fallback")
+
+        # test upper limit
+        fb1d_upperlim = OutofRangeFallback1D(self.function1d, -333, xmax=100)
+        self.assertEqual(fb1d_upperlim(100), 100., msg="Should return input")
+        self.assertEqual(fb1d_upperlim(1000), -333., msg="Should return fallback")
+
+    def test_fallback2d_init(self):
+
+        # test limits
+        with self.assertRaises(ValueError):
+            OutofRangeFallback2D(self.function2d, 0, xmin=10, xmax=10)
+            OutofRangeFallback2D(self.function2d, 0, xmin=10, xmax=-10)
+            OutofRangeFallback2D(self.function2d, 0, ymin=10, ymax=10)
+            OutofRangeFallback2D(self.function2d, 0, ymin=10, ymax=-10)
+
+    def test_fallback2d(self):
+
+        # nolimits
+        fb2d_nolim = OutofRangeFallback2D(self.function2d, 0)
+
+        self.assertEqual(fb2d_nolim(1, 1), 2, msg="should return sum of inputs")
+
+        # bottom limits
+        fb2d_bottomx = OutofRangeFallback2D(self.function2d, 333, xmin=-10)
+        self.assertEqual(fb2d_bottomx(-10, -20), -30., msg="should return sum of inputs")
+        self.assertEqual(fb2d_bottomx(-11, 200), 333., msg="should return fallback")
+
+        fb2d_bottomy = OutofRangeFallback2D(self.function2d, 333, ymin=-10)
+        self.assertEqual(fb2d_bottomy(-20, -10), -30., msg="should return sum of inputs")
+        self.assertEqual(fb2d_bottomy(10, -11), 333., msg="should return fallback")
+
+        fb2d_bottomxy = OutofRangeFallback2D(self.function2d, 333, xmin=-10, ymin=-10)
+        self.assertEqual(fb2d_bottomxy(-10, -10), -20., msg="should return sum of inputs")
+        self.assertEqual(fb2d_bottomxy(-11, 1), 333., msg="should return fallback")
+        self.assertEqual(fb2d_bottomxy(1, -11), 333., msg="should return fallback")
+        self.assertEqual(fb2d_bottomxy(-200, -200), 333., msg="should return fallback")
+
+        # upper limits
+        fb2d_upperx = OutofRangeFallback2D(self.function2d, 333, xmax=10)
+        self.assertEqual(fb2d_upperx(10, 20), 30., msg="should return sum of inputs")
+        self.assertEqual(fb2d_upperx(11, -200), 333., msg="should return fallback")
+
+        fb2d_uppery = OutofRangeFallback2D(self.function2d, 333, ymax=10)
+        self.assertEqual(fb2d_uppery(20, 10), 30., msg="should return sum of inputs")
+        self.assertEqual(fb2d_uppery(1, 11), 333., msg="should return fallback")
+
+        fb2d_upperxy = OutofRangeFallback2D(self.function2d, 333, xmax=10, ymax=10)
+        self.assertEqual(fb2d_upperxy(10, 10), 20., msg="should return sum of inputs")
+        self.assertEqual(fb2d_upperxy(11, 11), 333., msg="should return fallback")
+        self.assertEqual(fb2d_upperxy(1, 11), 333., msg="should return fallback")
+        self.assertEqual(fb2d_upperxy(11, 1), 333., msg="should return fallback")
+
+    def test_fallback3d_init(self):
+
+        # test limits
+        with self.assertRaises(ValueError):
+            OutofRangeFallback3D(self.function3d, 0, xmin=10, xmax=10)
+            OutofRangeFallback3D(self.function3d, 0, xmin=10, xmax=-10)
+            OutofRangeFallback3D(self.function3d, 0, ymin=10, ymax=10)
+            OutofRangeFallback3D(self.function3d, 0, ymin=10, ymax=-10)
+            OutofRangeFallback3D(self.function3d, 0, zmin=10, zmax=-10)
+            OutofRangeFallback3D(self.function3d, 0, zmin=10, zmax=-10)
+
+    def test_fallback3d(self):
+
+        # nolimits
+        fb3d_nolim = OutofRangeFallback3D(self.function3d, 0)
+
+        self.assertEqual(fb3d_nolim(1, 1, 1), 3, msg="should return sum of inputs")
+
+        # bottom limits
+        fb3d_bottomx = OutofRangeFallback3D(self.function3d, 333, xmin=-10)
+        self.assertEqual(fb3d_bottomx(-10, -20, -30), -60., msg="should return sum of inputs")
+        self.assertEqual(fb3d_bottomx(-11, -10, -10), 333., msg="should return sum of inputs")
+
+        fb3d_bottomy = OutofRangeFallback3D(self.function3d, 333, ymin=-10)
+        self.assertEqual(fb3d_bottomy(-20, -10, -30), -60., msg="should return sum of inputs")
+        self.assertEqual(fb3d_bottomy(10, -11, 30), 333., msg="should return fallback")
+
+        fb3d_bottomz = OutofRangeFallback3D(self.function3d, 333, zmin=-10)
+        self.assertEqual(fb3d_bottomz(-20, -20, -10), -50., msg="should return sum of inputs")
+        self.assertEqual(fb3d_bottomz(10, 10, -11), 333., msg="should return fallback")
+
+        fb3d_bottomxyz = OutofRangeFallback3D(self.function3d, 333, xmin=-10, ymin=-10, zmin=-10)
+        self.assertEqual(fb3d_bottomxyz(-10, -10, -10), -30., msg="should return sum of inputs")
+        self.assertEqual(fb3d_bottomxyz(-11, -10, -10), 333., msg="should return fallback")
+        self.assertEqual(fb3d_bottomxyz(-10, -11, -10), 333., msg="should return fallback")
+        self.assertEqual(fb3d_bottomxyz(-10, -10, -11), 333., msg="should return fallback")
+        self.assertEqual(fb3d_bottomxyz(-11, -11, -10), 333., msg="should return fallback")
+        self.assertEqual(fb3d_bottomxyz(-11, -10, -11), 333., msg="should return fallback")
+        self.assertEqual(fb3d_bottomxyz(-10, -11, -11), 333., msg="should return fallback")
+        self.assertEqual(fb3d_bottomxyz(-11, -11, -11), 333., msg="should return fallback")
+
+        # upper limits
+        fb3d_upperx = OutofRangeFallback3D(self.function3d, 333, xmax=10)
+        self.assertEqual(fb3d_upperx(10, 20, 20), 50., msg="should return sum of inputs")
+        self.assertEqual(fb3d_upperx(11, 5, 5), 333., msg="should return fallback")
+
+        fb3d_uppery = OutofRangeFallback3D(self.function3d, 333, ymax=10)
+        self.assertEqual(fb3d_uppery(20, 10, 20), 50., msg="should return sum of inputs")
+        self.assertEqual(fb3d_uppery(5, 11, 5), 333., msg="should return fallback")
+
+        fb3d_upperz = OutofRangeFallback3D(self.function3d, 333, zmax=10)
+        self.assertEqual(fb3d_upperz(20, 20, 10), 50., msg="should return sum of inputs")
+        self.assertEqual(fb3d_upperz(5, 5, 11), 333., msg="should return fallback")
+
+        fb3d_bottomxyz = OutofRangeFallback3D(self.function3d, 333, xmax=10, ymax=10, zmax=10)
+        self.assertEqual(fb3d_bottomxyz(10, 10, 10), 30., msg="should return sum of inputs")
+        self.assertEqual(fb3d_bottomxyz(11, 10, 10), 333., msg="should return fallback")
+        self.assertEqual(fb3d_bottomxyz(10, 11, 10), 333., msg="should return fallback")
+        self.assertEqual(fb3d_bottomxyz(10, 10, 11), 333., msg="should return fallback")
+        self.assertEqual(fb3d_bottomxyz(11, 11, 10), 333., msg="should return fallback")
+        self.assertEqual(fb3d_bottomxyz(11, 10, 11), 333., msg="should return fallback")
+        self.assertEqual(fb3d_bottomxyz(10, 11, 11), 333., msg="should return fallback")
+        self.assertEqual(fb3d_bottomxyz(11, 11, 11), 333., msg="should return fallback")

--- a/cherab/openadas/openadas.py
+++ b/cherab/openadas/openadas.py
@@ -36,10 +36,46 @@ class OpenADAS(AtomicData):
     :param bool wavelength_element_fallback: If true, allows to use the element's wavelength when
                                              the isotope's wavelength is not available.
                                              Default is False.
+    :param double ionisation_rate_fallback_value: If passed, informs the ionisation_rate interpolation
+                                                  object to return the passed value instead of extrapolation.
+    :param double recombination_rate_fallback_value: If passed, informs the recombination_rate interpolation
+                                                     object to return the passed value instead of extrapolation.
+    :param double thermal_cx_rate_fallback_value: If passed, informs the thermal_cx_rate interpolation
+                                                  object to return the passed value instead of extrapolation.
+    :param double beam_cx_pec_fallback_value: If passed, informs the beam_cx_pec interpolation
+                                              object to return the passed value instead of extrapolation.
+    :param double beam_stopping_rate_fallback_value: If passed, informs the beam_stopping_rate interpolation
+                                                     object to return the passed value instead of extrapolation.
+    :param double beam_population_rate_fallback_value: If passed, informs the beam_population_rate interpolation
+                                                       object to return the passed value instead of extrapolation.
+    :param double beam_emission_pec_fallback_value: If passed, informs the beam_beam_emission_pec interpolation
+                                                    object to return the passed value instead of extrapolation.
+    :param double impact_excitation_pec_fallback_value: If passed, informs the impact_excitation_pec interpolation
+                                                        object to return the passed value instead of extrapolation.
+    :param double recombination_pec_fallback_value: If passed, informs the recombination_pec interpolation
+                                                    object to return the passed value instead of extrapolation.
+    :param double line_radiated_power_fallback_value: If passed, informs the line_radiated_power interpolation
+                                                      object to return the passed value instead of extrapolation.
+    :param double continuum_radiated_power_fallback_value: If passed, informs the continuum_radiated_power interpolation
+                                                           object to return the passed value instead of extrapolation.
+    :param double cx_radiated_power_fallback_value: If passed, informs the cx_radiated_power interpolation
+                                                    object to return the passed value instead of extrapolation.
     """
 
     def __init__(self, data_path=None, permit_extrapolation=False, missing_rates_return_null=False,
-                 wavelength_element_fallback=False):
+                 wavelength_element_fallback=False,
+                 ionisation_rate_fallback_value=None,
+                 recombination_rate_fallback_value=None,
+                 thermal_cx_rate_fallback_value=None,
+                 beam_cx_pec_fallback_value=None,
+                 beam_stopping_rate_fallback_value=None,
+                 beam_population_rate_fallback_value=None,
+                 beam_emission_pec_fallback_value=None,
+                 impact_excitation_pec_fallback_value=None,
+                 recombination_pec_fallback_value=None,
+                 line_radiated_power_fallback_value=None,
+                 continuum_radiated_power_fallback_value=None,
+                 cx_radiated_power_fallback_value=None):
 
         super().__init__()
         self._data_path = data_path or DEFAULT_REPOSITORY_PATH
@@ -49,6 +85,18 @@ class OpenADAS(AtomicData):
         self._missing_rates_return_null = missing_rates_return_null
 
         self._wavelength_element_fallback = wavelength_element_fallback
+        self._ionisation_rate_fallback_value = ionisation_rate_fallback_value
+        self._recombination_rate_fallback_value = recombination_rate_fallback_value
+        self._thermal_cx_rate_fallback_value = thermal_cx_rate_fallback_value
+        self._beam_cx_pec_fallback_value = beam_cx_pec_fallback_value
+        self._beam_stopping_rate_fallback_value = beam_stopping_rate_fallback_value
+        self._beam_population_rate_fallback_value = beam_population_rate_fallback_value
+        self._beam_emission_pec_fallback_value = beam_emission_pec_fallback_value
+        self._impact_excitation_pec_fallback_value = impact_excitation_pec_fallback_value
+        self._recombination_pec_fallback_value = recombination_pec_fallback_value
+        self._line_radiated_power_fallback_value = line_radiated_power_fallback_value
+        self._continuum_radiated_power_fallback_value = continuum_radiated_power_fallback_value
+        self._cx_radiated_power_fallback_value = cx_radiated_power_fallback_value
 
     @property
     def data_path(self):
@@ -97,7 +145,8 @@ class OpenADAS(AtomicData):
                 return NullIonisationRate()
             raise
 
-        return IonisationRate(data, extrapolate=self._permit_extrapolation)
+        return IonisationRate(data, extrapolate=self._permit_extrapolation,
+                              rate_fallback=self._ionisation_rate_fallback_value)
 
     def recombination_rate(self, ion, charge):
         """
@@ -124,7 +173,8 @@ class OpenADAS(AtomicData):
                 return NullRecombinationRate()
             raise
 
-        return RecombinationRate(data, extrapolate=self._permit_extrapolation)
+        return RecombinationRate(data, extrapolate=self._permit_extrapolation,
+                                 rate_fallback=self._recombination_rate_fallback_value)
 
     def thermal_cx_rate(self, donor_element, donor_charge, receiver_element, receiver_charge):
         """
@@ -159,7 +209,8 @@ class OpenADAS(AtomicData):
                 return NullThermalCXRate()
             raise
 
-        return ThermalCXRate(data, extrapolate=self._permit_extrapolation)
+        return ThermalCXRate(data, extrapolate=self._permit_extrapolation,
+                             rate_fallback=self._thermal_cx_rate_fallback_value)
 
     def beam_cx_pec(self, donor_ion, receiver_ion, receiver_charge, transition):
         """
@@ -206,7 +257,8 @@ class OpenADAS(AtomicData):
         # load and interpolate the relevant transition data from each file
         rates = []
         for donor_metastable, rate_data in data:
-            rates.append(BeamCXPEC(donor_metastable, wavelength, rate_data, extrapolate=self._permit_extrapolation))
+            rates.append(BeamCXPEC(donor_metastable, wavelength, rate_data, extrapolate=self._permit_extrapolation,
+                                   rate_fallback=self._beam_cx_pec_fallback_value))
         return rates
 
     def beam_stopping_rate(self, beam_ion, plasma_ion, charge):
@@ -241,7 +293,8 @@ class OpenADAS(AtomicData):
             raise
 
         # load and interpolate data
-        return BeamStoppingRate(data, extrapolate=self._permit_extrapolation)
+        return BeamStoppingRate(data, extrapolate=self._permit_extrapolation,
+                                rate_fallback=self._beam_stopping_rate_fallback_value)
 
     def beam_population_rate(self, beam_ion, metastable, plasma_ion, charge):
         """
@@ -277,7 +330,8 @@ class OpenADAS(AtomicData):
             raise
 
         # load and interpolate data
-        return BeamPopulationRate(data, extrapolate=self._permit_extrapolation)
+        return BeamPopulationRate(data, extrapolate=self._permit_extrapolation,
+                                  rate_fallback=self._beam_population_rate_fallback_value)
 
     def beam_emission_pec(self, beam_ion, plasma_ion, charge, transition):
         """
@@ -318,7 +372,8 @@ class OpenADAS(AtomicData):
         wavelength = self.wavelength(beam_ion, 0, transition)
 
         # load and interpolate data
-        return BeamEmissionPEC(data, wavelength, extrapolate=self._permit_extrapolation)
+        return BeamEmissionPEC(data, wavelength, extrapolate=self._permit_extrapolation,
+                               rate_fallback=self._beam_emission_pec_fallback_value)
 
     def impact_excitation_pec(self, ion, charge, transition):
         """
@@ -351,7 +406,8 @@ class OpenADAS(AtomicData):
         # the wavelength is used ot convert the PEC from photons/s/m3 to W/m3
         wavelength = self.wavelength(ion, charge, transition)
 
-        return ImpactExcitationPEC(wavelength, data, extrapolate=self._permit_extrapolation)
+        return ImpactExcitationPEC(wavelength, data, extrapolate=self._permit_extrapolation,
+                                   rate_fallback=self._impact_excitation_pec_fallback_value)
 
     def recombination_pec(self, ion, charge, transition):
         """
@@ -384,7 +440,8 @@ class OpenADAS(AtomicData):
         # the wavelength is used ot convert the PEC from photons/s/m3 to W/m3
         wavelength = self.wavelength(ion, charge, transition)
 
-        return RecombinationPEC(wavelength, data, extrapolate=self._permit_extrapolation)
+        return RecombinationPEC(wavelength, data, extrapolate=self._permit_extrapolation,
+                                rate_fallback=self._recombination_pec_fallback_value)
 
     def line_radiated_power_rate(self, ion, charge):
         """
@@ -412,7 +469,8 @@ class OpenADAS(AtomicData):
                 return NullLineRadiationPower(ion, charge)
             raise
 
-        return LineRadiationPower(ion, charge, data, extrapolate=self._permit_extrapolation)
+        return LineRadiationPower(ion, charge, data, extrapolate=self._permit_extrapolation,
+                                  rate_fallback=self._line_radiated_power_fallback_value)
 
     def continuum_radiated_power_rate(self, ion, charge):
         """
@@ -440,7 +498,8 @@ class OpenADAS(AtomicData):
                 return NullContinuumPower(ion, charge)
             raise
 
-        return ContinuumPower(ion, charge, data, extrapolate=self._permit_extrapolation)
+        return ContinuumPower(ion, charge, data, extrapolate=self._permit_extrapolation,
+                              rate_fallback=self._continuum_radiated_power_fallback_value)
 
     def cx_radiated_power_rate(self, ion, charge):
         """
@@ -468,4 +527,5 @@ class OpenADAS(AtomicData):
                 return NullCXRadiationPower(ion, charge)
             raise
 
-        return CXRadiationPower(ion, charge, data, extrapolate=self._permit_extrapolation)
+        return CXRadiationPower(ion, charge, data, extrapolate=self._permit_extrapolation,
+                                rate_fallback=self._cx_radiated_power_fallback_value)

--- a/cherab/openadas/rates/atomic.pxd
+++ b/cherab/openadas/rates/atomic.pxd
@@ -27,6 +27,7 @@ cdef class IonisationRate(CoreIonisationRate):
     cdef:
         readonly dict raw_data
         readonly tuple density_range, temperature_range
+        readonly double rate_fallback
         Function2D _rate
 
 
@@ -39,6 +40,7 @@ cdef class RecombinationRate(CoreRecombinationRate):
     cdef:
         readonly dict raw_data
         readonly tuple density_range, temperature_range
+        readonly double rate_fallback
         Function2D _rate
 
 
@@ -51,6 +53,7 @@ cdef class ThermalCXRate(CoreThermalCXRate):
     cdef:
         readonly dict raw_data
         readonly tuple density_range, temperature_range
+        readonly double rate_fallback
         Function2D _rate
 
 

--- a/cherab/openadas/rates/beam.pxd
+++ b/cherab/openadas/rates/beam.pxd
@@ -28,9 +28,14 @@ cdef class BeamStoppingRate(CoreBeamStoppingRate):
         dict raw_data
         Function2D _npl_eb
         Function1D _tp
+        double _rate_fallback
         tuple beam_energy_range
         tuple density_range
         tuple temperature_range
+        double rate_fallback
+    
+    cdef:
+        bint _fallback
 
 
 cdef class NullBeamStoppingRate(CoreBeamStoppingRate):
@@ -46,6 +51,10 @@ cdef class BeamPopulationRate(CoreBeamPopulationRate):
         tuple beam_energy_range
         tuple density_range
         tuple temperature_range
+        double rate_fallback
+    
+    cdef:
+        bint _fallback
 
 
 cdef class NullBeamPopulationRate(CoreBeamPopulationRate):
@@ -62,7 +71,10 @@ cdef class BeamEmissionPEC(CoreBeamEmissionPEC):
         tuple beam_energy_range
         tuple density_range
         tuple temperature_range
+        double rate_fallback
 
+    cdef:
+        bint _fallback
 
 cdef class NullBeamEmissionPEC(CoreBeamEmissionPEC):
     pass

--- a/cherab/openadas/rates/cx.pxd
+++ b/cherab/openadas/rates/cx.pxd
@@ -32,6 +32,10 @@ cdef class BeamCXPEC(CoreBeamCXPEC):
         readonly tuple temperature_range
         readonly tuple zeff_range
         readonly tuple b_field_range
+        double rate_fallback
+    
+    cdef:
+        bint _fallback
 
 
 cdef class NullBeamCXPEC(CoreBeamCXPEC):

--- a/cherab/openadas/rates/pec.pxd
+++ b/cherab/openadas/rates/pec.pxd
@@ -26,7 +26,7 @@ cdef class ImpactExcitationPEC(CoreImpactExcitationPEC):
 
     cdef:
         readonly dict raw_data
-        readonly double wavelength
+        readonly double wavelength, rate_fallback
         readonly tuple density_range, temperature_range
         Function2D _rate
 
@@ -39,7 +39,7 @@ cdef class RecombinationPEC(CoreRecombinationPEC):
 
     cdef:
         readonly dict raw_data
-        readonly double wavelength
+        readonly double wavelength, rate_fallback
         readonly tuple density_range, temperature_range
         Function2D _rate
 

--- a/cherab/openadas/rates/radiated_power.pxd
+++ b/cherab/openadas/rates/radiated_power.pxd
@@ -29,6 +29,7 @@ cdef class LineRadiationPower(CoreLineRadiationPower):
     cdef:
         readonly dict raw_data
         readonly tuple density_range, temperature_range
+        double rate_fallback
         Function2D _rate
 
 
@@ -41,6 +42,7 @@ cdef class ContinuumPower(CoreContinuumPower):
     cdef:
         readonly dict raw_data
         readonly tuple density_range, temperature_range
+        double rate_fallback
         Function2D _rate
 
 
@@ -53,6 +55,7 @@ cdef class CXRadiationPower(CoreCXRadiationPower):
     cdef:
         readonly dict raw_data
         readonly tuple density_range, temperature_range
+        readonly double rate_fallback
         Function2D _rate
 
 

--- a/cherab/openadas/tests/test_fallback.py
+++ b/cherab/openadas/tests/test_fallback.py
@@ -1,0 +1,81 @@
+import unittest
+
+from cherab.core.atomic.elements import helium, hydrogen, carbon
+from cherab.openadas import OpenADAS
+
+
+class TestRateFallback(unittest.TestCase):
+
+    def test_rates_fallback(self):
+
+        atomic_data = OpenADAS(permit_extrapolation=True,
+                               ionisation_rate_fallback_value=0)
+        rate = atomic_data.ionisation_rate(helium, 1)
+        self.assertEqual(rate(0.9 * rate.density_range[0], 0.9 * rate.temperature_range[0]), 0)
+
+        atomic_data = OpenADAS(permit_extrapolation=True,
+                               recombination_rate_fallback_value=0)
+        rate = atomic_data.recombination_rate(helium, 1)
+        self.assertEqual(rate(0.9 * rate.density_range[0], 0.9 * rate.temperature_range[0]), 0)
+
+        atomic_data = OpenADAS(permit_extrapolation=True,
+                               thermal_cx_rate_fallback_value=0)
+        rate = atomic_data.thermal_cx_rate(hydrogen, 0, carbon, 6)
+        self.assertEqual(rate(0.9 * rate.density_range[0], 0.9 * rate.temperature_range[0]), 0)
+
+        atomic_data = OpenADAS(permit_extrapolation=True,
+                               beam_cx_pec_fallback_value=0)
+        rate = atomic_data.beam_cx_pec(hydrogen, carbon, 6, (8, 7))
+        for rt in rate:
+            self.assertEqual(rt(0.9 * rt.beam_energy_range[0],
+                                0.9 * rt.temperature_range[0],
+                                0.9 * rt.density_range[0],
+                                0.9 * rt.zeff_range[0],
+                                0.9 * rt.b_field_range[0]
+                                ), 0)
+
+        atomic_data = OpenADAS(permit_extrapolation=True,
+                               beam_stopping_rate_fallback_value=0)
+        rate = atomic_data.beam_stopping_rate(hydrogen, carbon, 6)
+        self.assertEqual(rate(0.9 * rate.beam_energy_range[0],
+                              0.9 * rate.density_range[0],
+                              0.9 * rate.temperature_range[0]), 0)
+        
+        atomic_data = OpenADAS(permit_extrapolation=True,
+                               beam_population_rate_fallback_value=0)
+        rate = atomic_data.beam_population_rate(hydrogen, 2, carbon, 6)
+        self.assertEqual(rate(0.9 * rate.beam_energy_range[0],
+                              0.9 * rate.density_range[0],
+                              0.9 * rate.temperature_range[0]), 0)
+
+        atomic_data = OpenADAS(permit_extrapolation=True,
+                               beam_emission_pec_fallback_value=0)
+        rate = atomic_data.beam_emission_pec(hydrogen, carbon, 6, (3, 2))
+        self.assertEqual(rate(0.9 * rate.beam_energy_range[0],
+                              0.9 * rate.density_range[0],
+                              0.9 * rate.temperature_range[0]), 0)
+
+        atomic_data = OpenADAS(permit_extrapolation=True,
+                               impact_excitation_pec_fallback_value=0)
+        rate =  atomic_data.impact_excitation_pec(hydrogen, 0, (3, 2))
+        self.assertEqual(rate(0.9 * rate.density_range[0], 0.9 * rate.temperature_range[0]), 0)
+
+        atomic_data = OpenADAS(permit_extrapolation=True,
+                               recombination_pec_fallback_value=0)
+        rate = atomic_data.recombination_pec(hydrogen, 0, (3, 2))
+        self.assertEqual(rate(0.9 * rate.density_range[0], 0.9 * rate.temperature_range[0]), 0)
+
+        atomic_data = OpenADAS(permit_extrapolation=True,
+                               line_radiated_power_fallback_value=0)
+        rate = atomic_data.line_radiated_power_rate(helium, 1)
+        self.assertEqual(rate(0.9 * rate.density_range[0], 0.9 * rate.temperature_range[0]), 0)
+
+        atomic_data = OpenADAS(permit_extrapolation=True,
+                               continuum_radiated_power_fallback_value=0)
+        rate = atomic_data.continuum_radiated_power_rate(helium, 1)
+        self.assertEqual(rate(0.9 * rate.density_range[0], 0.9 * rate.temperature_range[0]), 0)
+
+        atomic_data = OpenADAS(permit_extrapolation=True,
+                               cx_radiated_power_fallback_value=0)
+        rate = atomic_data.cx_radiated_power_rate(helium, 1)
+        self.assertEqual(rate(0.9 * rate.density_range[0], 0.9 * rate.temperature_range[0]), 0)

--- a/docs/source/math/fallback.rst
+++ b/docs/source/math/fallback.rst
@@ -1,0 +1,6 @@
+
+Out of Range Fallback
+------
+
+.. automodule:: cherab.core.math.fallback
+   :members:

--- a/docs/source/math/math.rst
+++ b/docs/source/math/math.rst
@@ -15,6 +15,7 @@ utilities that Cherab provides for slicing, dicing and projecting these function
 .. toctree::
    caching
    clamp
+   fallback
    function
    interpolators
    mappers


### PR DESCRIPTION
This adds rate fallback to the open adas rate interpolators, is related to the issue #367 

The rate extrapolation can now be handled by returning the fallback
value. This is achieved by
1) using the new OutofRangexD function wrappers
2) adding conditions directly to the evaluate methods. This was done
   in case of evaluation methods using more advanced formulae

This PR should follow the #368 

I would like to ask @vsnever and @jacklovell to check this PR. If there is a more efficient way how to handle the fallback, then I will be happy to change the PR. 