### PR TITLE
Fix CI by pinning raysect install version in script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,11 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Python dependencies
-      run: python -m pip install cython>=0.28 numpy==${{ matrix.numpy-version }} scipy matplotlib pyopencl[pocl]
+      run: python -m pip install cython>=0.28 numpy==${{ matrix.numpy-version }} scipy matplotlib pyopencl[pocl]==2022.1
     - name: Work around PyOpenCL issue 537
       run: echo OCL_ICD_VENDORS=$(python -c 'import os, pyopencl; print(os.path.join(*pyopencl.__path__, ".libs"))') >> $GITHUB_ENV
     - name: Install Raysect from pypi
-      run: pip install raysect
+      run: pip install raysect==0.7.1
     - name: Build cherab
       run: dev/build.sh
     - name: Run tests


### PR DESCRIPTION
Specify raysect 0.7.1 in the CI script, since now that 0.8 is out that is installed by default. Also need to pin pyopencl to 2022.1 to workout OpenCL issue 573.

I anticipate the versioning issues will be improved once we support raysect 0.8, as that's migrated to a PEP-517-compliant pyproject.toml that means we don't have to manually install the raysect dependencies and raysect itself before building Cherab: we can let pip do the dependency management in future.