### PR TITLE
Update CI with new python and numpy versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Python dependencies
-      run: python -m pip install cython>=0.28 ${{ matrix.numpy-version }} scipy matplotlib pyopencl[pocl]==2022.1
-    - name: Work around PyOpenCL issue 537
-      run: echo OCL_ICD_VENDORS=$(python -c 'import os, pyopencl; print(os.path.join(*pyopencl.__path__, ".libs"))') >> $GITHUB_ENV
+      run: python -m pip install cython>=0.28 ${{ matrix.numpy-version }} scipy matplotlib "pyopencl[pocl]>=2022.2.4"
     - name: Install Raysect from pypi
       run: pip install raysect==0.7.1
     - name: Build cherab

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Python dependencies
-      run: python -m pip install cython>=0.28 ${{ matrix.numpy-version }} scipy matplotlib "pyopencl[pocl]>=2022.2.4"
+      run: python -m pip install --prefer-binary cython>=0.28 ${{ matrix.numpy-version }} scipy matplotlib "pyopencl[pocl]>=2022.2.4"
     - name: Install Raysect from pypi
       run: pip install raysect==0.7.1
     - name: Build cherab

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        numpy-version: ["1.15.0", "1.16.6", "1.19.2"]
-        python-version: ["3.6", "3.7", "3.8"]
-        exclude:
-          - python-version: "3.8"
-            numpy-version: "1.15.0"
+        numpy-version: ["oldest-supported-numpy", "numpy"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
@@ -26,7 +23,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Python dependencies
-      run: python -m pip install cython>=0.28 numpy==${{ matrix.numpy-version }} scipy matplotlib pyopencl[pocl]==2022.1
+      run: python -m pip install cython>=0.28 ${{ matrix.numpy-version }} scipy matplotlib pyopencl[pocl]==2022.1
     - name: Work around PyOpenCL issue 537
       run: echo OCL_ICD_VENDORS=$(python -c 'import os, pyopencl; print(os.path.join(*pyopencl.__path__, ".libs"))') >> $GITHUB_ENV
     - name: Install Raysect from pypi


### PR DESCRIPTION
- Remove python 3.6 from CI, as it's no longer supported on ubuntu-latest.
- Only test on oldest-supported and newest-pre-built numpy versions for each Python version.
- Update pyopencl version in CI to one which fixes the missing POCL library issue previously worked around.