### PR TITLE
Fix coverage configuration to properly omit test files

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,4 @@
 [run]
 plugins = Cython.Coverage
 source = cherab
-omit = *tests*
+omit = */tests/*


### PR DESCRIPTION
Omit wildcard was incorrect: should specify tests directories at all levels.