### PR TITLE
Build extensions in parallel by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ with a build-time dependency on Cherab need to use a Cython version newer than
 3.0a5, due to a [bug](https://github.com/cython/cython/issues/2918) in how
 earlier versions of Cython handle namespaces.
 
+By default, pip will install from wheel archives on PyPI. If a binary wheel is not
+available for your version of Python, or if you are installing in editable mode
+for development, the package will be compiled locally on your machine. Compilation
+is done in parallel by default, using all available processors, but can be
+overridden by setting the environment variable `CHERAB_NCPU` to the number of
+processors to use.
+
 Governance
 ----------
 

--- a/docs/source/installation_and_structure.rst
+++ b/docs/source/installation_and_structure.rst
@@ -82,6 +82,12 @@ line to install the packages under your own user account. Alternatively, conside
 `virtual environment <https://docs.python.org/3/tutorial/venv.html>`_ to avoid the risk of
 conflicting versions of packages in your Python environment.
 
+By default, pip will install from wheel archives on PyPI. If a binary wheel is not available for
+your version of Python, or if you are installing from source in editable mode for development (see
+below), the package will be compiled locally on your machine. Compilation is done in parallel by
+default, using all available processors, but can be overridden by setting the environment variable
+``CHERAB_NCPU`` to the number of processors to use.
+
 
 Installing from source
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,9 @@ compilation_includes = [".", numpy.get_include()]
 compilation_args = ["-O3"]
 cython_directives = {"language_level": 3}
 setup_path = path.dirname(path.abspath(__file__))
+num_processes = int(os.getenv("CHERAB_NCPU", "-1"))
+if num_processes == -1:
+    num_processes = multiprocessing.cpu_count()
 
 if line_profile:
     compilation_args.append("-DCYTHON_TRACE=1")
@@ -109,6 +112,9 @@ setup(
     include_package_data=True,
     zip_safe=False,
     ext_modules=extensions,
+    options=dict(
+        build_ext={"parallel": num_processes},
+    ),
 )
 
 # setup a rate repository with common rates


### PR DESCRIPTION
This speeds up installation from source using pip, where it is otherwise cumbersome to pass the `--parallel` option to `setup.py build_ext`.