### PR TITLE
Package demo scripts and data in sdists and wheels

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,0 @@
-include CHANGELOG.md CITE.md AUTHORS.md
-include cherab/core/VERSION
-recursive-include cherab *.pyx *.pxd *.json *.cl *.npy *.obj

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,3 @@
-include README.md CHANGELOG.md LICENSE.txt CITE.md AUTHORS.md MANIFEST.in setup.py requirements.txt .gitignore
+include CHANGELOG.md CITE.md AUTHORS.md
 include cherab/core/VERSION
-recursive-include cherab *.py *.pyx *.pxd *.json *.cl *.npy *.obj
-prune demos*
-
-
+recursive-include cherab *.pyx *.pxd *.json *.cl *.npy *.obj

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel", "oldest-supported-numpy", "cython>=0.28", "raysect==0.8.1"]
+requires = ["setuptools>=62.3", "oldest-supported-numpy", "cython>=0.28", "raysect==0.8.1"]
 build-backend="setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -117,12 +117,13 @@ setup(
         "matplotlib",
         "raysect==0.8.1",
     ],
-    packages=find_packages(include=["cherab"]),
+    packages=find_packages(include=["cherab*"]),
     package_data={"": [
         "**/*.pyx", "**/*.pxd",  # Needed to build Cython extensions.
         "**/*.json", "**/*.cl", "**/*.npy", "**/*.obj",  # Supplementary data
-        "cherab/core/VERSION",  # Used by cherab.core to determine version at run time
-    ]},
+    ],
+                  "cherab.core": ["VERSION"],  # Used to determine version at run time
+    },
     data_files=data_files,
     zip_safe=False,
     ext_modules=extensions,

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,10 @@
 from setuptools import setup, find_packages, Extension
+from collections import defaultdict
 import sys
 import numpy
 import os
 import os.path as path
+from pathlib import Path
 import multiprocessing
 from Cython.Build import cythonize
 
@@ -68,6 +70,16 @@ extensions = cythonize(
     compiler_directives=cython_directives,
 )
 
+# Include demos in a separate directory in the distribution as data_files.
+demo_parent_path = Path("share/cherab/demos/core")
+data_files = defaultdict(list)
+demos_source = Path("demos")
+for item in demos_source.rglob("*"):
+    if item.is_file():
+        install_dir = demo_parent_path / item.parent.relative_to(demos_source)
+        data_files[str(install_dir)].append(str(item))
+data_files = list(data_files.items())
+
 # parse the package version number
 with open(path.join(path.dirname(__file__), "cherab/core/VERSION")) as version_file:
     version = version_file.read().strip()
@@ -105,8 +117,9 @@ setup(
         "matplotlib",
         "raysect==0.8.1",
     ],
-    packages=find_packages(),
+    packages=find_packages(include=["cherab*"]),
     include_package_data=True,
+    data_files=data_files,
     zip_safe=False,
     ext_modules=extensions,
 )

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,11 @@
-from setuptools import setup, find_packages, Extension
 from collections import defaultdict
 import sys
-import numpy
 import os
 import os.path as path
 from pathlib import Path
 import multiprocessing
+import numpy
+from setuptools import setup, find_packages, Extension
 from Cython.Build import cythonize
 
 multiprocessing.set_start_method('fork')
@@ -117,8 +117,12 @@ setup(
         "matplotlib",
         "raysect==0.8.1",
     ],
-    packages=find_packages(include=["cherab*"]),
-    include_package_data=True,
+    packages=find_packages(include=["cherab"]),
+    package_data={"": [
+        "**/*.pyx", "**/*.pxd",  # Needed to build Cython extensions.
+        "**/*.json", "**/*.cl", "**/*.npy", "**/*.obj",  # Supplementary data
+        "cherab/core/VERSION",  # Used by cherab.core to determine version at run time
+    ]},
     data_files=data_files,
     zip_safe=False,
     ext_modules=extensions,


### PR DESCRIPTION
This enables users who haven't cloned the git repository to still run the demos. Use distutils/setuptools' support for `data_files` to achieve this.

Also remove MANIFEST.in and `include_package_data=True`, use setuptools' `find_packages` and `package_data` instead. This allows finer control over what gets packaged, and fixes a deprecation warning in recent setuptools versions (see
https://github.com/pypa/setuptools/pull/3308 for details). It also prevents Cython-transpiled C source files being included in the wheel distribution, which roughly halves the size of the installed distribution.