### PR TITLE
Add 'units' attribute to RayTransferPipeline#D

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ New:
 * Support Raysect 0.8
 * Add PeriodicTransformXD and VectorPeriodicTransformXD functions to support the data simulated with periodic boundary conditions. (#387)
 * Add CylindricalTransform and VectorCylindricalTransform to transform functions from cylindrical to Cartesian coordinates. (#387)
-* Add the units attribute to RayTransferPipelineXD that determines whether the ray transfer matrix is multiplied by sensitivity or not. (#412)
+* Add the kind attribute to RayTransferPipelineXD that determines whether the ray transfer matrix is multiplied by sensitivity ('power') or not ('radiance'). (#412)
 
 
 Release 1.4.0 (3 Feb 2023)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,11 @@ Project Changelog
 Release 1.5.0 (TBD)
 -------------------
 
-Bug fixes:
-* Fix improper multiplication by sensitivity factor in RayTransferPixelProcessor resulting in wrong units (m^3 sr instead of m) of ray transfer matrices. (#412)
-
 New:
 * Support Raysect 0.8
 * Add PeriodicTransformXD and VectorPeriodicTransformXD functions to support the data simulated with periodic boundary conditions. (#387)
 * Add CylindricalTransform and VectorCylindricalTransform to transform functions from cylindrical to Cartesian coordinates. (#387)
+* Add the units attribute to RayTransferPipelineXD that determines whether the ray transfer matrix is multiplied by sensitivity or not. (#412)
 
 
 Release 1.4.0 (3 Feb 2023)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Project Changelog
 Release 1.5.0 (TBD)
 -------------------
 
+Bug fixes:
+* Fix improper multiplication by sensitivity factor in RayTransferPixelProcessor resulting in wrong units (m^3 sr instead of m) of ray transfer matrices. (#412)
+
 New:
 * Support Raysect 0.8
 * Add PeriodicTransformXD and VectorPeriodicTransformXD functions to support the data simulated with periodic boundary conditions. (#387)

--- a/cherab/tools/raytransfer/pipelines.py
+++ b/cherab/tools/raytransfer/pipelines.py
@@ -75,7 +75,7 @@ class RayTransferPipeline0D(Pipeline0D, RayTransferPipelineBase):
     Simple 0D pipeline for ray transfer matrix (geometry matrix) calculation.
 
     :param str name: The name of the pipeline. Default is 'RayTransferPipeline0D'.
-    :param str kind: The kind of the pipeline. Can be 'power' or 'radiance'.
+    :param str kind: The kind of the pipeline. Can be 'power' (default) or 'radiance'.
         In the case of 'power', the resulting matrix is multiplied by the sensitivity
         of the detector, and the units of the matrix are [m^3 sr], which gives the units
         of power [W] for the product of the ray transfer matrix and the emission profile.
@@ -121,7 +121,7 @@ class RayTransferPipeline1D(Pipeline1D, RayTransferPipelineBase):
     Simple 1D pipeline for ray transfer matrix (geometry matrix) calculation.
 
     :param str name: The name of the pipeline. Default is 'RayTransferPipeline0D'.
-    :param str kind: The kind of the pipeline. Can be 'power' or 'radiance'.
+    :param str kind: The kind of the pipeline. Can be 'power' (default) or 'radiance'.
         In the case of 'power', the resulting matrix is multiplied by the sensitivity
         of the detector, and the units of the matrix are [m^3 sr], which gives the units
         of power [W] for the product of the ray transfer matrix and the emission profile.
@@ -168,7 +168,7 @@ class RayTransferPipeline2D(Pipeline2D, RayTransferPipelineBase):
     Simple 2D pipeline for ray transfer matrix (geometry matrix) calculation.
 
     :param str name: The name of the pipeline. Default is 'RayTransferPipeline0D'.
-    :param str kind: The kind of the pipeline. Can be 'power' or 'radiance'.
+    :param str kind: The kind of the pipeline. Can be 'power' (default) or 'radiance'.
         In the case of 'power', the resulting matrix is multiplied by the sensitivity
         of the detector, and the units of the matrix are [m^3 sr], which gives the units
         of power [W] for the product of the ray transfer matrix and the emission profile.

--- a/cherab/tools/raytransfer/pipelines.py
+++ b/cherab/tools/raytransfer/pipelines.py
@@ -34,24 +34,63 @@ import numpy as np
 from raysect.optical.observer.base import Pipeline0D, Pipeline1D, Pipeline2D, PixelProcessor
 
 
-class RayTransferPipeline0D(Pipeline0D):
+class RayTransferPipelineBase():
+
+    def __init__(self, name=None, units='power'):
+
+        self.name = name
+        self._matrix = None
+        self._samples = 0
+        self._bins = 0
+        self.units = units
+
+    @property
+    def units(self):
+        """
+        The units in which the matrix is calculated. Can be 'power' or 'radiance'.
+        The 'power' stands for [m^3 sr] and the 'radiance' stands for [m].
+        """
+        return self._units
+
+    @units.setter
+    def units(self, value):
+        _units = value.lower()
+        if _units in ('power', 'radiance'):
+            self._units = _units
+        else:
+            raise ValueError("The units property must be 'power' or 'radiance'.")
+
+    @property
+    def matrix(self):
+        return self._matrix
+
+
+class RayTransferPipeline0D(Pipeline0D, RayTransferPipelineBase):
     """
     Simple 0D pipeline for ray transfer matrix (geometry matrix) calculation.
+
+    :param str name: The name of the pipeline. Default is 'RayTransferPipeline0D'.
+    :param str units: The units in which the matrix is calculated. Can
+                      be 'power' (default) or 'radiance'.
+                      The 'power' stands for [m^3 sr] and when the matrix is collapsed with
+                      the emission profile [W m^-3 sr-1 nm-1] it gives the power [W nm-1].
+                      The 'radiance' stands for [m] and when the matrix is collapsed with
+                      the emission profile it gives the radiance [W m^-2 sr-1 nm-1].
+                      If the 'power' is selected, the matrix is multiplied by the detector sensitivity.
+                      Note that if the detector sensitivity is 1, the 'power' and 'radiance'
+                      give the same results.
 
     :ivar np.ndarray matrix: Ray transfer matrix, a 1D array of size :math:`N_{bin}`.
 
     .. code-block:: pycon
 
        >>> from cherab.tools.raytransfer import RayTransferPipeline0D
-       >>> pipeline = RayTransferPipeline0D()
+       >>> pipeline = RayTransferPipeline0D(units='radiance')
     """
 
-    def __init__(self, name=None):
+    def __init__(self, name='RayTransferPipeline0D', units='power'):
 
-        self.name = name or 'RayTransferPipeline0D'
-        self._matrix = None
-        self._samples = 0
-        self._bins = 0
+        RayTransferPipelineBase.__init__(self, name, units)
 
     def initialise(self, min_wavelength, max_wavelength, spectral_bins, spectral_slices, quiet):
         self._samples = 0
@@ -59,7 +98,10 @@ class RayTransferPipeline0D(Pipeline0D):
         self._matrix = np.zeros(spectral_bins)
 
     def pixel_processor(self, slice_id):
-        return RayTransferPixelProcessor(self._bins)
+        if self._units == 'power':
+            return PowerRayTransferPixelProcessor(self._bins)
+        else:
+            return RadianceRayTransferPixelProcessor(self._bins)
 
     def update(self, slice_id, packed_result, pixel_samples):
         self._samples += pixel_samples
@@ -68,30 +110,34 @@ class RayTransferPipeline0D(Pipeline0D):
     def finalise(self):
         self._matrix /= self._samples
 
-    @property
-    def matrix(self):
-        return self._matrix
 
-
-class RayTransferPipeline1D(Pipeline1D):
+class RayTransferPipeline1D(Pipeline1D, RayTransferPipelineBase):
     """
     Simple 1D pipeline for ray transfer matrix (geometry matrix) calculation.
+
+    :param str name: The name of the pipeline. Default is 'RayTransferPipeline0D'.
+    :param str units: The units in which the matrix is calculated. Can
+                      be 'power' (default) or 'radiance'.
+                      The 'power' stands for [m^3 sr] and when the matrix is collapsed with
+                      the emission profile [W m^-3 sr-1 nm-1] it gives the power [W nm-1].
+                      The 'radiance' stands for [m] and when the matrix is collapsed with
+                      the emission profile it gives the radiance [W m^-2 sr-1 nm-1].
+                      If the 'power' is selected, the matrix is multiplied by the detector sensitivity.
+                      Note that if the detector sensitivity is 1, the 'power' and 'radiance'
+                      give the same results.
 
     :ivar np.ndarray matrix: Ray transfer matrix, a 2D array of shape :math:`(N_{pixel}, N_{bin})`.
 
     .. code-block:: pycon
 
        >>> from cherab.tools.raytransfer import RayTransferPipeline1D
-       >>> pipeline = RayTransferPipeline1D()
+       >>> pipeline = RayTransferPipeline1D(units='radiance')
     """
 
-    def __init__(self, name=None):
+    def __init__(self, name='RayTransferPipeline1D', units='power'):
 
-        self.name = name or 'RayTransferPipeline1D'
-        self._matrix = None
+        RayTransferPipelineBase.__init__(self, name, units)
         self._pixels = None
-        self._samples = 0
-        self._bins = 0
 
     def initialise(self, pixels, pixel_samples, min_wavelength, max_wavelength, spectral_bins, spectral_slices, quiet):
         self._pixels = pixels
@@ -100,7 +146,10 @@ class RayTransferPipeline1D(Pipeline1D):
         self._matrix = np.zeros((pixels, spectral_bins))
 
     def pixel_processor(self, pixel, slice_id):
-        return RayTransferPixelProcessor(self._bins)
+        if self._units == 'power':
+            return PowerRayTransferPixelProcessor(self._bins)
+        else:
+            return RadianceRayTransferPixelProcessor(self._bins)
 
     def update(self, pixel, slice_id, packed_result):
         self._matrix[pixel] = packed_result[0] / self._samples
@@ -108,30 +157,34 @@ class RayTransferPipeline1D(Pipeline1D):
     def finalise(self):
         pass
 
-    @property
-    def matrix(self):
-        return self._matrix
 
-
-class RayTransferPipeline2D(Pipeline2D):
+class RayTransferPipeline2D(Pipeline2D, RayTransferPipelineBase):
     """
     Simple 2D pipeline for ray transfer matrix (geometry matrix) calculation.
+
+    :param str name: The name of the pipeline. Default is 'RayTransferPipeline0D'.
+    :param str units: The units in which the matrix is calculated. Can
+                      be 'power' (default) or 'radiance'.
+                      The 'power' stands for [m^3 sr] and when the matrix is collapsed with
+                      the emission profile [W m^-3 sr-1 nm-1] it gives the power [W nm-1].
+                      The 'radiance' stands for [m] and when the matrix is collapsed with
+                      the emission profile it gives the radiance [W m^-2 sr-1 nm-1].
+                      If the 'power' is selected, the matrix is multiplied by the detector sensitivity.
+                      Note that if the detector sensitivity is 1, the 'power' and 'radiance'
+                      give the same results.
 
     :ivar np.ndarray matrix: Ray transfer matrix, a 3D array of shape :math:`(N_x, N_y, N_{bin})`.
 
     .. code-block:: pycon
 
        >>> from cherab.tools.raytransfer import RayTransferPipeline2D
-       >>> pipeline = RayTransferPipeline2D()
+       >>> pipeline = RayTransferPipeline2D(units='radiance')
     """
 
-    def __init__(self, name=None):
+    def __init__(self, name='RayTransferPipeline2D', units='power'):
 
-        self.name = name or 'RayTransferPipeline2D'
-        self._matrix = None
+        RayTransferPipelineBase.__init__(self, name, units)
         self._pixels = None
-        self._samples = 0
-        self._bins = 0
 
     def initialise(self, pixels, pixel_samples, min_wavelength, max_wavelength, spectral_bins, spectral_slices, quiet):
         self._pixels = pixels
@@ -140,7 +193,10 @@ class RayTransferPipeline2D(Pipeline2D):
         self._matrix = np.zeros((pixels[0], pixels[1], spectral_bins))
 
     def pixel_processor(self, x, y, slice_id):
-        return RayTransferPixelProcessor(self._bins)
+        if self._units == 'power':
+            return PowerRayTransferPixelProcessor(self._bins)
+        else:
+            return RadianceRayTransferPixelProcessor(self._bins)
 
     def update(self, x, y, slice_id, packed_result):
         self._matrix[x, y] = packed_result[0] / self._samples
@@ -148,21 +204,32 @@ class RayTransferPipeline2D(Pipeline2D):
     def finalise(self):
         pass
 
-    @property
-    def matrix(self):
-        return self._matrix
 
-
-class RayTransferPixelProcessor(PixelProcessor):
+class RayTransferPixelProcessorBase(PixelProcessor):
     """
-    PixelProcessor that stores ray transfer matrix for each pixel.
+    Base class for PixelProcessor that stores ray transfer matrix for each pixel.
     """
 
     def __init__(self, bins):
         self._matrix = np.zeros(bins)
 
-    def add_sample(self, spectrum, sensitivity):
-        self._matrix += spectrum.samples * sensitivity
-
     def pack_results(self):
         return (self._matrix, 0)
+
+
+class RadianceRayTransferPixelProcessor(RayTransferPixelProcessorBase):
+    """
+    PixelProcessor that stores ray transfer matrix in the units of [m] for each pixel.
+    """
+
+    def add_sample(self, spectrum, sensitivity):
+        self._matrix += spectrum.samples
+
+
+class PowerRayTransferPixelProcessor(RayTransferPixelProcessorBase):
+    """
+    PixelProcessor that stores ray transfer matrix in the units of [m^3 sr] for each pixel.
+    """
+
+    def add_sample(self, spectrum, sensitivity):
+        self._matrix += spectrum.samples * sensitivity

--- a/cherab/tools/tests/test_raytransfer.py
+++ b/cherab/tools/tests/test_raytransfer.py
@@ -252,18 +252,18 @@ class TestRayTransferPipeline0D(unittest.TestCase):
         Test initialise method.
         """
         nbins = 10
-        pipeline = RayTransferPipeline0D('test_pipeline_0D', units='power')
+        pipeline = RayTransferPipeline0D('test_pipeline_0D', kind='power')
         pipeline.initialise(0, 0, nbins, 0, 0)
 
         self.assertTrue(pipeline.matrix.shape == (nbins,))
         self.assertTrue(pipeline.name == 'test_pipeline_0D')
-        self.assertTrue(pipeline.units == 'power')
+        self.assertTrue(pipeline.kind == 'power')
 
         self.assertRaises(ValueError, RayTransferPipeline0D, 'test_pipeline_0D', 'blah')
 
-    def test_units(self):
+    def test_kind(self):
         """
-        Test if the 'units' attribute works properly.
+        Test if the 'kind' attribute works properly.
         """
         nbins = 10
         sensitivity = 2.
@@ -271,7 +271,7 @@ class TestRayTransferPipeline0D(unittest.TestCase):
         spectrum = Spectrum(1., 2., nbins)
         spectrum.samples[:] = spectral_value
 
-        pipeline = RayTransferPipeline0D('test_pipeline_0D', units='power')
+        pipeline = RayTransferPipeline0D('test_pipeline_0D', kind='power')
         pipeline.initialise(0, 0, nbins, 0, 0)
 
         pixel_processor = pipeline.pixel_processor(0)
@@ -281,7 +281,7 @@ class TestRayTransferPipeline0D(unittest.TestCase):
         matrix, _ = pixel_processor.pack_results()  # multiplied by sensitivity
         self.assertTrue(np.all(matrix == sensitivity * spectral_value))
 
-        pipeline.units = 'radiance'
+        pipeline.kind = 'radiance'
         pixel_processor = pipeline.pixel_processor(0)
         pixel_processor.add_sample(spectrum, sensitivity)
 
@@ -301,19 +301,19 @@ class TestRayTransferPipeline1D(unittest.TestCase):
         nbins = 10
         pixels = 20
         samples = 1
-        pipeline = RayTransferPipeline1D('test_pipeline_1D', units='radiance')
+        pipeline = RayTransferPipeline1D('test_pipeline_1D', kind='radiance')
         pipeline.initialise(pixels, samples, 0, 0, nbins, 1, 0)
 
         self.assertTrue(pipeline.matrix.shape == (pixels, nbins))
         self.assertTrue(pipeline.name == 'test_pipeline_1D')
-        self.assertTrue(pipeline.units == 'radiance')
+        self.assertTrue(pipeline.kind == 'radiance')
         self.assertTrue(pipeline._samples == samples)
 
         self.assertRaises(ValueError, RayTransferPipeline1D, 'test_pipeline_1D', 'blah')
 
-    def test_units(self):
+    def test_kind(self):
         """
-        Test if the 'units' attribute works properly.
+        Test if the 'kind' attribute works properly.
         """
         nbins = 10
         pixels = 20
@@ -323,7 +323,7 @@ class TestRayTransferPipeline1D(unittest.TestCase):
         spectrum = Spectrum(1., 2., nbins)
         spectrum.samples[:] = spectral_value
 
-        pipeline = RayTransferPipeline1D('test_pipeline_1D', units='power')
+        pipeline = RayTransferPipeline1D('test_pipeline_1D', kind='power')
         pipeline.initialise(pixels, samples, 0, 0, nbins, 1, 0)
 
         pixel_processor = pipeline.pixel_processor(0, 0)
@@ -333,7 +333,7 @@ class TestRayTransferPipeline1D(unittest.TestCase):
         matrix, _ = pixel_processor.pack_results()  # multiplied by sensitivity
         self.assertTrue(np.all(matrix == sensitivity * spectral_value))
 
-        pipeline.units = 'radiance'
+        pipeline.kind = 'radiance'
         pixel_processor = pipeline.pixel_processor(0, 0)
         pixel_processor.add_sample(spectrum, sensitivity)
 
@@ -353,19 +353,19 @@ class TestRayTransferPipeline2D(unittest.TestCase):
         nbins = 10
         pixels = (20, 5)
         samples = 1
-        pipeline = RayTransferPipeline2D('test_pipeline_2D', units='radiance')
+        pipeline = RayTransferPipeline2D('test_pipeline_2D', kind='radiance')
         pipeline.initialise(pixels, samples, 0, 0, nbins, 1, 0)
 
         self.assertTrue(pipeline.matrix.shape == (pixels[0], pixels[1], nbins))
         self.assertTrue(pipeline.name == 'test_pipeline_2D')
-        self.assertTrue(pipeline.units == 'radiance')
+        self.assertTrue(pipeline.kind == 'radiance')
         self.assertTrue(pipeline._samples == samples)
 
         self.assertRaises(ValueError, RayTransferPipeline2D, 'test_pipeline_2D', 'blah')
 
     def test_units(self):
         """
-        Test if the 'units' attribute works properly.
+        Test if the 'kind' attribute works properly.
         """
         nbins = 10
         pixels = (20, 5)
@@ -375,7 +375,7 @@ class TestRayTransferPipeline2D(unittest.TestCase):
         spectrum = Spectrum(1., 2., nbins)
         spectrum.samples[:] = spectral_value
 
-        pipeline = RayTransferPipeline2D('test_pipeline_2D', units='power')
+        pipeline = RayTransferPipeline2D('test_pipeline_2D', kind='power')
         pipeline.initialise(pixels, samples, 0, 0, nbins, 1, 0)
 
         pixel_processor = pipeline.pixel_processor(0, 0, 0)
@@ -385,7 +385,7 @@ class TestRayTransferPipeline2D(unittest.TestCase):
         matrix, _ = pixel_processor.pack_results()  # multiplied by sensitivity
         self.assertTrue(np.all(matrix == sensitivity * spectral_value))
 
-        pipeline.units = 'radiance'
+        pipeline.kind = 'radiance'
         pixel_processor = pipeline.pixel_processor(0, 0, 0)
         pixel_processor.add_sample(spectrum, sensitivity)
 

--- a/demos/observers/bolometry/geometry_matrix_with_raytransfer.py
+++ b/demos/observers/bolometry/geometry_matrix_with_raytransfer.py
@@ -240,7 +240,7 @@ sensitivity_matrix = []
 for camera in cameras:
     for foil in camera:
         print("Calculating sensitivity for {}...".format(foil.name))
-        foil.pipelines = [RayTransferPipeline0D()]
+        foil.pipelines = [RayTransferPipeline0D(units=foil.units)]
         # All objects in world have wavelength-independent material properties,
         # so it doesn't matter which wavelength range we use (as long as
         # max_wavelength - min_wavelength = 1)

--- a/demos/observers/bolometry/geometry_matrix_with_raytransfer.py
+++ b/demos/observers/bolometry/geometry_matrix_with_raytransfer.py
@@ -240,7 +240,7 @@ sensitivity_matrix = []
 for camera in cameras:
     for foil in camera:
         print("Calculating sensitivity for {}...".format(foil.name))
-        foil.pipelines = [RayTransferPipeline0D(units=foil.units)]
+        foil.pipelines = [RayTransferPipeline0D(kind=foil.units)]
         # All objects in world have wavelength-independent material properties,
         # so it doesn't matter which wavelength range we use (as long as
         # max_wavelength - min_wavelength = 1)

--- a/demos/ray_transfer/1_ray_transfer_box.py
+++ b/demos/ray_transfer/1_ray_transfer_box.py
@@ -66,8 +66,8 @@ rtb = RayTransferBox(120., 80., 10., 12, 8, 1, transform=translate(-60., 0, 0), 
 rtb.step = 0.2
 
 # creating ray transfer pipeline
-# Be careful when choosing pipeline units ('power' or 'radiance').
-# In case of 'power', the matrix [m] is multiplied by the detector's sensitivity [m^2 sr].
+# Be careful when setting the 'kind' attribute of the pipeline to 'power' or 'radiance'.
+# In the case of 'power', the matrix [m] is multiplied by the detector's sensitivity [m^2 sr].
 # For the PinholeCamera this does not matter, because its pixel sensitivity is 1.
 pipeline = RayTransferPipeline2D()
 

--- a/demos/ray_transfer/1_ray_transfer_box.py
+++ b/demos/ray_transfer/1_ray_transfer_box.py
@@ -36,8 +36,8 @@ from raysect.optical import World, translate, rotate, Point3D
 from raysect.optical.observer import PinholeCamera, FullFrameSampler2D
 
 # RayTransferPipeline2D is optimised for calculation of ray transfer matrices.
-# It's also possible to use SpectralRadiancePipeline2D but for the matrices with >1000 elements
-# the performance will be lower.
+# It's also possible to use SpectralRadiancePipeline2D or SpectralPowerPipeline2D but
+# for the matrices with >1000 elements the performance will be lower.
 from cherab.tools.raytransfer import RayTransferPipeline2D, RayTransferBox
 
 # Here we use special materials optimised for calculation of ray transfer matrices.
@@ -66,6 +66,9 @@ rtb = RayTransferBox(120., 80., 10., 12, 8, 1, transform=translate(-60., 0, 0), 
 rtb.step = 0.2
 
 # creating ray transfer pipeline
+# Be careful when choosing pipeline units ('power' or 'radiance').
+# In case of 'power', the matrix [m] is multiplied by the detector's sensitivity [m^2 sr].
+# For the PinholeCamera this does not matter, because its pixel sensitivity is 1.
 pipeline = RayTransferPipeline2D()
 
 # setting up the camera


### PR DESCRIPTION
This PR fixes #412 by adding `units` attribute to `RayTransferPipeline#D`, which can be either 'power' or 'radiance', similar to the Power and Radiance pipelines. This attribute determines whether the ray transfer matrix is multiplied by the sensitivity of the detector ('power') or not ('radiance').

The `RayTransferPixelProcessor` class is now split into two subclasses: `PowerRayTransferPixelProcessor` and `RadianceRayTransferPixelProcessor`.

The `RayTransferPipeline#D` classes now inherit from both `Pipeline#D` classes and the new `RayTransferPipelineBase` class.

The tests for `RayTransferPipeline#D` are added.