### PR TITLE
Fix update bug of LaserMaterial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ New:
 * Add the kind attribute to RayTransferPipelineXD that determines whether the ray transfer matrix is multiplied by sensitivity ('power') or not ('radiance'). (#412)
 
 Bug fixes:
-* Fix deprecated cached transforms in LaserMaterial after laser.transform update
+* Fix deprecated transforms being cached in LaserMaterial after laser.transform update (#420)
 
 Release 1.4.0 (3 Feb 2023)
 -------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ New:
 * Add CylindricalTransform and VectorCylindricalTransform to transform functions from cylindrical to Cartesian coordinates. (#387)
 * Add the kind attribute to RayTransferPipelineXD that determines whether the ray transfer matrix is multiplied by sensitivity ('power') or not ('radiance'). (#412)
 
+Bug fixes:
+* Fix deprecated cached transforms in LaserMaterial after laser.transform update
 
 Release 1.4.0 (3 Feb 2023)
 -------------------

--- a/cherab/core/laser/material.pxd
+++ b/cherab/core/laser/material.pxd
@@ -17,7 +17,7 @@
 # under the Licence.
 
 
-from raysect.core.scenegraph._nodebase cimport _NodeBase
+from raysect.core cimport Primitive
 from raysect.core.math cimport AffineMatrix3D
 from raysect.optical.material.emitter cimport InhomogeneousVolumeEmitter
 
@@ -28,4 +28,8 @@ cdef class LaserMaterial(InhomogeneousVolumeEmitter):
 
     cdef:
         AffineMatrix3D _laser_to_plasma, _laser_segment_to_laser_node
+        Primitive _primitive
+        Laser _laser
         list _models
+
+    cdef void _cache_transforms(self)

--- a/cherab/core/laser/node.pxd
+++ b/cherab/core/laser/node.pxd
@@ -53,3 +53,5 @@ cdef class Laser(Node):
         VolumeIntegrator _integrator
         
     cdef object __weakref__
+
+    cdef Plasma get_plasma(self)

--- a/cherab/core/laser/node.pyx
+++ b/cherab/core/laser/node.pyx
@@ -153,6 +153,12 @@ cdef class Laser(Node):
         self._plasma.notifier.add(self._plasma_changed)
 
         self._configure_materials()
+    
+    cdef Plasma get_plasma(self):
+        """
+        Fast method to obtain laser's plasma reference.
+        """
+        return self._plasma
 
     @property
     def importance(self):
@@ -255,7 +261,7 @@ cdef class Laser(Node):
 
     def _plasma_changed(self):
         """React to change of plasma and propagate the information."""
-        self.configure_geometry()
+        self._configure_materials()
 
     def _modified(self):
-        self.configure_geometry()
+        self._configure_materials()

--- a/cherab/core/laser/node.pyx
+++ b/cherab/core/laser/node.pyx
@@ -255,7 +255,7 @@ cdef class Laser(Node):
 
     def _plasma_changed(self):
         """React to change of plasma and propagate the information."""
-        self._configure_materials()
+        self.configure_geometry()
 
     def _modified(self):
-        self._configure_materials()
+        self.configure_geometry()


### PR DESCRIPTION
Fixes problem described in #420 

In short:
Laser primitives are now dropped and recreated after Laser.transform changes which removes the problem of old transfomrs being cached in LaserMaterial

