### PR TITLE
Add support for Apple GPUs to get_flops() function.

### DIFF
--- a/cherab/tools/inversions/opencl/opencl_utils.py
+++ b/cherab/tools/inversions/opencl/opencl_utils.py
@@ -75,7 +75,7 @@ def get_flops(device, verbose=False):
     elif "amd" in vendor or "advanced" in vendor:
         try:
             ww = device.get_info(cl.device_info.WAVEFRONT_WIDTH_AMD)
-        except:
+        except AttributeError:
             ww = 64
         gflops = comp_units * ww * 2 * gpu_clock / 1000.
 
@@ -84,6 +84,10 @@ def get_flops(device, verbose=False):
 
     elif "arm" in vendor:
         gflops = comp_units * 2 * 16 * gpu_clock / 1000.
+
+    elif "apple" in vendor:
+        alu_lanes = 128
+        gflops = comp_units * 2 * alu_lanes * gpu_clock / 1000.
 
     else:
         warnings.warn('Unsupported device vendor: {}. Unable to estimate theoretical peak performance.'.format(vendor))


### PR DESCRIPTION
This fixes #429 by providing performance estimates for Apple GPUs in the `get_flops()` function.

According to [wikipedia](https://en.wikipedia.org/wiki/Apple_silicon#Comparison_of_M_series_processors), Apple GPUs on the M1, M2 and M3 SoCs have 128 FP32 ALU lanes per core (compute unit).