### PR TITLE
Fix incorrect docstrings for atomic rate base classes

### DIFF
--- a/cherab/core/atomic/rates.pxd
+++ b/cherab/core/atomic/rates.pxd
@@ -75,7 +75,7 @@ cdef class TotalRadiatedPower:
     cdef:
         readonly Element element
 
-    cdef double evaluate(self, double density, double temperature) except? -1e999
+    cdef double evaluate(self, double electron_density, double electron_temperature) except? -1e999
 
 
 cdef class _RadiatedPower:
@@ -84,7 +84,7 @@ cdef class _RadiatedPower:
         readonly Element element
         readonly int charge
 
-    cdef double evaluate(self, double density, double temperature) except? -1e999
+    cdef double evaluate(self, double electron_density, double electron_temperature) except? -1e999
 
 
 cdef class LineRadiationPower(_RadiatedPower):
@@ -106,4 +106,4 @@ cdef class FractionalAbundance:
         readonly int charge
         public str name
 
-    cdef double evaluate(self, double density, double temperature) except? -1e999
+    cdef double evaluate(self, double electron_density, double electron_temperature) except? -1e999

--- a/cherab/core/atomic/rates.pxd
+++ b/cherab/core/atomic/rates.pxd
@@ -75,7 +75,7 @@ cdef class TotalRadiatedPower:
     cdef:
         readonly Element element
 
-    cdef double evaluate(self, double electron_density, double electron_temperature) except? -1e999
+    cdef double evaluate(self, double density, double temperature) except? -1e999
 
 
 cdef class _RadiatedPower:
@@ -84,7 +84,7 @@ cdef class _RadiatedPower:
         readonly Element element
         readonly int charge
 
-    cdef double evaluate(self, double electron_density, double electron_temperature) except? -1e999
+    cdef double evaluate(self, double density, double temperature) except? -1e999
 
 
 cdef class LineRadiationPower(_RadiatedPower):
@@ -106,4 +106,4 @@ cdef class FractionalAbundance:
         readonly int charge
         public str name
 
-    cdef double evaluate(self, double electron_density, double electron_temperature) except? -1e999
+    cdef double evaluate(self, double density, double temperature) except? -1e999

--- a/cherab/core/atomic/rates.pyx
+++ b/cherab/core/atomic/rates.pyx
@@ -227,20 +227,20 @@ cdef class TotalRadiatedPower():
 
         self.element = element
 
-    def __call__(self, double density, double temperature):
+    def __call__(self, double electron_density, double electron_temperature):
         """
         Evaluate the total radiated power rate at the given plasma conditions.
 
         This function just wraps the cython evaluate() method.
         """
-        return self.evaluate(density, temperature)
+        return self.evaluate(electron_density, electron_temperature)
 
-    cdef double evaluate(self, double density, double temperature) except? -1e999:
+    cdef double evaluate(self, double electron_density, double electron_temperature) except? -1e999:
         """
         Evaluate the total radiated power rate at the given plasma conditions.
 
-        :param float density: Electron density in m^-3.
-        :param float temperature: Electron temperature in eV.
+        :param float electron_density: Electron density in m^-3.
+        :param float electron_temperature: Electron temperature in eV.
 
         :return: The total radiated power rate in W.m^3.
         """
@@ -255,15 +255,15 @@ cdef class _RadiatedPower:
         self.element = element
         self.charge = charge
 
-    def __call__(self, double density, double temperature):
+    def __call__(self, double electron_density, double electron_temperature):
         """
         Evaluate the radiated power rate at the given plasma conditions.
 
         This function just wraps the cython evaluate() method.
         """
-        return self.evaluate(density, temperature)
+        return self.evaluate(electron_density, electron_temperature)
 
-    cdef double evaluate(self, double density, double temperature) except? -1e999:
+    cdef double evaluate(self, double electron_density, double electron_temperature) except? -1e999:
         """
         Evaluate the radiated power at the given plasma conditions.
 
@@ -320,24 +320,24 @@ cdef class FractionalAbundance:
             raise ValueError("Charge state must be neutral or positive.")
         self.charge = charge
 
-    cdef double evaluate(self, double density, double temperature) except? -1e999:
+    cdef double evaluate(self, double electron_density, double electron_temperature) except? -1e999:
         """
         Evaluate the fractional abundance of this ionisation stage at the given plasma conditions.
 
-        :param float density: Electron density in m^-3.
-        :param float temperature: Electron temperature in eV.
+        :param float electron_density: Electron density in m^-3.
+        :param float electron_temperature: Electron temperature in eV.
 
         :return: Fractional abundance.
         """
         raise NotImplementedError("The evaluate() virtual method must be implemented.")
 
-    def __call__(self, double density, double temperature):
+    def __call__(self, double electron_density, double electron_temperature):
         """
         Evaluate the fractional abundance of this ionisation stage at the given plasma conditions.
 
         This function just wraps the cython evaluate() method.
         """
-        return self.evaluate(density, temperature)
+        return self.evaluate(electron_density, electron_temperature)
 
     def plot_temperature(self, temp_low=1, temp_high=1000, num_points=100, dens=1E19):
 

--- a/cherab/core/atomic/rates.pyx
+++ b/cherab/core/atomic/rates.pyx
@@ -35,9 +35,9 @@ cdef class IonisationRate:
     cpdef double evaluate(self, double density, double temperature) except? -1e999:
         """Returns an effective ionisation rate coefficient at the specified plasma conditions.
 
+        :param density: Electron density in m^-3.
         :param temperature: Electron temperature in eV.
-        :param density: Electron density in m^-3
-        :return: The effective ionisation rate in m^-3.
+        :return: The effective ionisation rate in m^3.s^-1.
         """
         raise NotImplementedError("The evaluate() virtual method must be implemented.")
 
@@ -57,9 +57,9 @@ cdef class RecombinationRate:
     cpdef double evaluate(self, double density, double temperature) except? -1e999:
         """Returns an effective recombination rate coefficient at the specified plasma conditions.
 
+        :param density: Electron density in m^-3.
         :param temperature: Electron temperature in eV.
-        :param density: Electron density in m^-3
-        :return: The effective ionisation rate in m^-3.
+        :return: The effective ionisation rate in m^3.s^-1.
         """
         raise NotImplementedError("The evaluate() virtual method must be implemented.")
 
@@ -79,9 +79,9 @@ cdef class ThermalCXRate:
     cpdef double evaluate(self, double density, double temperature) except? -1e999:
         """Returns an effective charge exchange rate coefficient at the specified plasma conditions.
 
+        :param density: Electron density in m^-3.
         :param temperature: Electron temperature in eV.
-        :param density: Electron density in m^-3
-        :return: The effective charge exchange rate in m^-3.
+        :return: The effective charge exchange rate in m^3.s^-1.
         """
         raise NotImplementedError("The evaluate() virtual method must be implemented.")
 
@@ -101,9 +101,9 @@ cdef class _PECRate:
     cpdef double evaluate(self, double density, double temperature) except? -1e999:
         """Returns a photon emissivity coefficient at given conditions.
 
-        :param temperature: Receiver ion temperature in eV.
-        :param density: Receiver ion density in m^-3
-        :return: The effective PEC rate in W/m^3.
+        :param density: Electron density in m^-3.
+        :param temperature: Electron temperature in eV.
+        :return: The effective PEC rate in W.m^3.
         """
         raise NotImplementedError("The evaluate() virtual method must be implemented.")
 
@@ -221,29 +221,28 @@ cdef class BeamEmissionPEC(_BeamRate):
 
 
 cdef class TotalRadiatedPower():
-    """The total radiated power in equilibrium conditions."""
+    """The total radiated power rate in equilibrium conditions."""
 
     def __init__(self, Element element):
 
         self.element = element
 
-    def __call__(self, double electron_density, double electron_temperature):
+    def __call__(self, double density, double temperature):
         """
-        Evaluate the radiated power rate at the given plasma conditions.
+        Evaluate the total radiated power rate at the given plasma conditions.
 
-        Calls the cython evaluate() method under the hood.
-
-        :param float electron_density: electron density in m^-3
-        :param float electron_temperature: electron temperature in eV
+        This function just wraps the cython evaluate() method.
         """
-        return self.evaluate(electron_density, electron_temperature)
+        return self.evaluate(density, temperature)
 
-    cdef double evaluate(self, double electron_density, double electron_temperature) except? -1e999:
+    cdef double evaluate(self, double density, double temperature) except? -1e999:
         """
-        Evaluate the radiated power at the given plasma conditions.
+        Evaluate the total radiated power rate at the given plasma conditions.
 
-        :param float electron_density: electron density in m^-3
-        :param float electron_temperature: electron temperature in eV
+        :param float density: Electron density in m^-3.
+        :param float temperature: Electron temperature in eV.
+
+        :return: The total radiated power rate in W.m^3.
         """
         raise NotImplementedError("The evaluate() virtual method must be implemented.")
 
@@ -256,23 +255,22 @@ cdef class _RadiatedPower:
         self.element = element
         self.charge = charge
 
-    def __call__(self, double electron_density, double electron_temperature):
+    def __call__(self, double density, double temperature):
         """
         Evaluate the radiated power rate at the given plasma conditions.
 
-        Calls the cython evaluate() method under the hood.
-
-        :param float electron_density: electron density in m^-3
-        :param float electron_temperature: electron temperature in eV
+        This function just wraps the cython evaluate() method.
         """
-        return self.evaluate(electron_density, electron_temperature)
+        return self.evaluate(density, temperature)
 
-    cdef double evaluate(self, double electron_density, double electron_temperature) except? -1e999:
+    cdef double evaluate(self, double density, double temperature) except? -1e999:
         """
         Evaluate the radiated power at the given plasma conditions.
 
-        :param float electron_density: electron density in m^-3
-        :param float electron_temperature: electron temperature in eV
+        :param float density: Electron density in m^-3.
+        :param float temperature: Electron temperature in eV.
+
+        :return: The radiated power rate in W.m^3.
         """
         raise NotImplementedError("The evaluate() virtual method must be implemented.")
 
@@ -308,9 +306,9 @@ cdef class FractionalAbundance:
     """
     Rate provider for fractional abundances in thermodynamic equilibrium.
 
-    :param Element element: the radiating element
-    :param int charge: the integer charge state for this ionisation stage
-    :param str name: optional label identifying this rate
+    :param Element element: the radiating element.
+    :param int charge: the integer charge state for this ionisation stage.
+    :param str name: optional label identifying this rate.
     """
 
     def __init__(self, element, charge, name=''):
@@ -322,23 +320,24 @@ cdef class FractionalAbundance:
             raise ValueError("Charge state must be neutral or positive.")
         self.charge = charge
 
-    cdef double evaluate(self, double electron_density, double electron_temperature) except? -1e999:
+    cdef double evaluate(self, double density, double temperature) except? -1e999:
         """
         Evaluate the fractional abundance of this ionisation stage at the given plasma conditions.
 
-        :param float electron_density: electron density in m^-3
-        :param float electron_temperature: electron temperature in eV
+        :param float density: Electron density in m^-3.
+        :param float temperature: Electron temperature in eV.
+
+        :return: Fractional abundance.
         """
         raise NotImplementedError("The evaluate() virtual method must be implemented.")
 
-    def __call__(self, double electron_density, double electron_temperature):
+    def __call__(self, double density, double temperature):
         """
         Evaluate the fractional abundance of this ionisation stage at the given plasma conditions.
 
-        :param float electron_density: electron density in m^-3
-        :param float electron_temperature: electron temperature in eV
+        This function just wraps the cython evaluate() method.
         """
-        return self.evaluate(electron_density, electron_temperature)
+        return self.evaluate(density, temperature)
 
     def plot_temperature(self, temp_low=1, temp_high=1000, num_points=100, dens=1E19):
 


### PR DESCRIPTION
This updates the docstrings for the atomic process rate base classes and fixes #431.