### PR TITLE
Fix Sphinx warnings about documents not being included in toctree

### DIFF
--- a/docs/source/demonstrations/active_spectroscopy/beam_bes.rst
+++ b/docs/source/demonstrations/active_spectroscopy/beam_bes.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 
 .. _beam_bes:
 

--- a/docs/source/demonstrations/active_spectroscopy/beam_cxs.rst
+++ b/docs/source/demonstrations/active_spectroscopy/beam_cxs.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 
 .. _beam_cxs:
 

--- a/docs/source/demonstrations/atomic_data/beam_plasma_interactions.rst
+++ b/docs/source/demonstrations/atomic_data/beam_plasma_interactions.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 
 .. _beam_plasma_interaction_rates:
 

--- a/docs/source/demonstrations/atomic_data/fractional_abundance.rst
+++ b/docs/source/demonstrations/atomic_data/fractional_abundance.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 
 .. _fractional_abundances:
 

--- a/docs/source/demonstrations/atomic_data/photon_emissivity_coefficients.rst
+++ b/docs/source/demonstrations/atomic_data/photon_emissivity_coefficients.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 
 .. _photon_emissivity_coefficients:
 

--- a/docs/source/demonstrations/atomic_data/radiated_powers.rst
+++ b/docs/source/demonstrations/atomic_data/radiated_powers.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 
 .. _radiated_powers:
 

--- a/docs/source/demonstrations/bolometry/calculate_etendue.rst
+++ b/docs/source/demonstrations/bolometry/calculate_etendue.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. _bolometer_etendue:
 
 

--- a/docs/source/demonstrations/bolometry/camera_from_mesh_and_coordinates.rst
+++ b/docs/source/demonstrations/bolometry/camera_from_mesh_and_coordinates.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. _bolometer_from_mesh:
 
 

--- a/docs/source/demonstrations/bolometry/camera_from_primitives.rst
+++ b/docs/source/demonstrations/bolometry/camera_from_primitives.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. _bolometer_from_primitives:
 
 

--- a/docs/source/demonstrations/bolometry/geometry_matrix_from_voxels.rst
+++ b/docs/source/demonstrations/bolometry/geometry_matrix_from_voxels.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. _bolometer_geometry_voxels:
 
 

--- a/docs/source/demonstrations/bolometry/geometry_matrix_with_raytransfer.rst
+++ b/docs/source/demonstrations/bolometry/geometry_matrix_with_raytransfer.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. _bolometer_geometry_raytransfer:
 
 

--- a/docs/source/demonstrations/bolometry/inversion_with_raytransfer.rst
+++ b/docs/source/demonstrations/bolometry/inversion_with_raytransfer.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. _bolometer_raytransfer_inversion:
 
 

--- a/docs/source/demonstrations/bolometry/inversion_with_voxels.rst
+++ b/docs/source/demonstrations/bolometry/inversion_with_voxels.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. _bolometer_voxel_inversion:
 
 

--- a/docs/source/demonstrations/bolometry/observing_radiation_function.rst
+++ b/docs/source/demonstrations/bolometry/observing_radiation_function.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. _bolometer_observing_radiation:
 
 

--- a/docs/source/demonstrations/demonstrations.rst
+++ b/docs/source/demonstrations/demonstrations.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 
 Atomic Data
 ===========

--- a/docs/source/demonstrations/jet_cxrs/jet_demo_76666.rst
+++ b/docs/source/demonstrations/jet_cxrs/jet_demo_76666.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 
 .. _jet_cxrs_76666:
 

--- a/docs/source/demonstrations/jet_cxrs/quickstart.rst
+++ b/docs/source/demonstrations/jet_cxrs/quickstart.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 
 .. _jet_cxrs_quickstart:
 

--- a/docs/source/demonstrations/line_emission/balmer_series_spectra.rst
+++ b/docs/source/demonstrations/line_emission/balmer_series_spectra.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 
 .. _balmer_series_spectra:
 

--- a/docs/source/demonstrations/line_emission/custom_emitter.rst
+++ b/docs/source/demonstrations/line_emission/custom_emitter.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 
 .. _custom_emitter:
 

--- a/docs/source/demonstrations/line_emission/mastu_forward_cameras.rst
+++ b/docs/source/demonstrations/line_emission/mastu_forward_cameras.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 
 .. _mastu_forward_cameras:
 

--- a/docs/source/demonstrations/passive_spectroscopy/balmer_series.rst
+++ b/docs/source/demonstrations/passive_spectroscopy/balmer_series.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 
 .. _impact_recom_lines:
 

--- a/docs/source/demonstrations/passive_spectroscopy/multiplet.rst
+++ b/docs/source/demonstrations/passive_spectroscopy/multiplet.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 
 .. _multiplet_lines:
 

--- a/docs/source/demonstrations/passive_spectroscopy/stark_broadening.rst
+++ b/docs/source/demonstrations/passive_spectroscopy/stark_broadening.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 
 .. _stark_broadening:
 

--- a/docs/source/demonstrations/passive_spectroscopy/zeeman_spectroscopy.rst
+++ b/docs/source/demonstrations/passive_spectroscopy/zeeman_spectroscopy.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 
 .. _zeeman_spectroscopy:
 

--- a/docs/source/demonstrations/plasmas/analytic_function_plasma.rst
+++ b/docs/source/demonstrations/plasmas/analytic_function_plasma.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 
 .. _analytic_function_plasma:
 

--- a/docs/source/demonstrations/plasmas/beams_into_plasmas.rst
+++ b/docs/source/demonstrations/plasmas/beams_into_plasmas.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 
 .. _beams_into_plasmas:
 

--- a/docs/source/demonstrations/plasmas/equilibrium.rst
+++ b/docs/source/demonstrations/plasmas/equilibrium.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. _flux_function_plasmas:
 
 Flux Function Plasmas

--- a/docs/source/demonstrations/plasmas/mesh2d_plasma.rst
+++ b/docs/source/demonstrations/plasmas/mesh2d_plasma.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 
 .. _mesh2d_plasma:
 

--- a/docs/source/demonstrations/plasmas/slab_plasma.rst
+++ b/docs/source/demonstrations/plasmas/slab_plasma.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 
 .. _slab_plasma:
 

--- a/docs/source/demonstrations/radiation_loads/radiation_function.rst
+++ b/docs/source/demonstrations/radiation_loads/radiation_function.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 
 .. _radiation_function:
 

--- a/docs/source/demonstrations/radiation_loads/surface_radiation_loads.rst
+++ b/docs/source/demonstrations/radiation_loads/surface_radiation_loads.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 
 .. _aug_solps_radiation_load:
 

--- a/docs/source/demonstrations/radiation_loads/symmetric_power_load.rst
+++ b/docs/source/demonstrations/radiation_loads/symmetric_power_load.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 
 .. _symmetric_power_load:
 

--- a/docs/source/demonstrations/radiation_loads/wall_from_polygon.rst
+++ b/docs/source/demonstrations/radiation_loads/wall_from_polygon.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 
 .. _wall_from_polygon:
 

--- a/docs/source/demonstrations/ray_transfer/ray_transfer_box.rst
+++ b/docs/source/demonstrations/ray_transfer/ray_transfer_box.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 
 .. _ray_transfer_box:
 

--- a/docs/source/demonstrations/ray_transfer/ray_transfer_cylinder.rst
+++ b/docs/source/demonstrations/ray_transfer/ray_transfer_cylinder.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 
 .. _ray_transfer_cylinder:
 

--- a/docs/source/demonstrations/ray_transfer/ray_transfer_map.rst
+++ b/docs/source/demonstrations/ray_transfer/ray_transfer_map.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 
 .. _ray_transfer_map:
 

--- a/docs/source/demonstrations/ray_transfer/ray_transfer_mask.rst
+++ b/docs/source/demonstrations/ray_transfer/ray_transfer_mask.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 
 .. _ray_transfer_mask:
 

--- a/docs/source/demonstrations/solps/solps_plasma.rst
+++ b/docs/source/demonstrations/solps/solps_plasma.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 
 .. _mastu_solps_plasma:
 


### PR DESCRIPTION
The demos are in fact not included in any toctree, but they are not intended to be so mark them as orphans as recommended in the Sphinx documentation.

These warnings make it harder to spot other - genuine - warnings, so removing them is useful for ensuring documentation is produced correctly.