### PR TITLE
Add docstrings for ExcitationLine and RecombinationLine emission models.

### DIFF
--- a/cherab/core/model/plasma/impact_excitation.pyx
+++ b/cherab/core/model/plasma/impact_excitation.pyx
@@ -23,6 +23,29 @@ from cherab.core.utility.constants cimport RECIP_4_PI
 
 
 cdef class ExcitationLine(PlasmaModel):
+    """
+    Emitter that calculates spectral line emission from a plasma object
+    as a result of excitation of the target species by electron impact.
+
+    .. math::
+        \\epsilon_{\\mathrm{excit}}(\\lambda) = \\frac{1}{4 \\pi} n_{Z_\\mathrm{i}} n_\\mathrm{e}
+        \\mathrm{PEC}_{\\mathrm{excit}}(n_\\mathrm{e}, T_\\mathrm{e}) f(\\lambda),
+
+    where :math:`n_{Z_\\mathrm{i}}` is the target species density,
+    :math:`\\mathrm{PEC}_{\\mathrm{excit}}` is the electron impact excitation photon emission coefficient
+    for the specified spectral line of the :math:`Z_\\mathrm{i}` ion,
+    :math:`f(\\lambda)` is the normalised spectral line shape,
+
+    :param Line line: Spectroscopic emission line object.
+    :param Plasma plasma: The plasma to which this emission model is attached. Default is None.
+    :param AtomicData atomic_data: The atomic data provider for this model. Default is None.
+    :param object lineshape: Line shape model class. Default is None (GaussianLine).
+    :param object lineshape_args: A list of line shape model arguments. Default is None.
+    :param object lineshape_kwargs: A dictionary of line shape model keyword arguments. Default is None.
+
+    :ivar Plasma plasma: The plasma to which this emission model is attached.
+    :ivar AtomicData atomic_data: The atomic data provider for this model.
+    """
 
     def __init__(self, Line line, Plasma plasma=None, AtomicData atomic_data=None, object lineshape=None,
                  object lineshape_args=None, object lineshape_kwargs=None):

--- a/cherab/core/model/plasma/impact_excitation.pyx
+++ b/cherab/core/model/plasma/impact_excitation.pyx
@@ -23,18 +23,18 @@ from cherab.core.utility.constants cimport RECIP_4_PI
 
 
 cdef class ExcitationLine(PlasmaModel):
-    """
+    r"""
     Emitter that calculates spectral line emission from a plasma object
     as a result of excitation of the target species by electron impact.
 
     .. math::
-        \\epsilon_{\\mathrm{excit}}(\\lambda) = \\frac{1}{4 \\pi} n_{Z_\\mathrm{i}} n_\\mathrm{e}
-        \\mathrm{PEC}_{\\mathrm{excit}}(n_\\mathrm{e}, T_\\mathrm{e}) f(\\lambda),
+        \epsilon_{\mathrm{excit}}(\lambda) = \frac{1}{4 \pi} n_{Z_\mathrm{i}} n_\mathrm{e}
+        \mathrm{PEC}_{\mathrm{excit}}(n_\mathrm{e}, T_\mathrm{e}) f(\lambda),
 
-    where :math:`n_{Z_\\mathrm{i}}` is the target species density,
-    :math:`\\mathrm{PEC}_{\\mathrm{excit}}` is the electron impact excitation photon emission coefficient
-    for the specified spectral line of the :math:`Z_\\mathrm{i}` ion,
-    :math:`f(\\lambda)` is the normalised spectral line shape,
+    where :math:`n_{Z_\mathrm{i}}` is the target species density,
+    :math:`\mathrm{PEC}_{\mathrm{excit}}` is the electron impact excitation photon emission coefficient
+    for the specified spectral line of the :math:`Z_\mathrm{i}` ion,
+    :math:`f(\lambda)` is the normalised spectral line shape,
 
     :param Line line: Spectroscopic emission line object.
     :param Plasma plasma: The plasma to which this emission model is attached. Default is None.

--- a/cherab/core/model/plasma/recombination.pyx
+++ b/cherab/core/model/plasma/recombination.pyx
@@ -23,18 +23,18 @@ from cherab.core.utility.constants cimport RECIP_4_PI
 
 
 cdef class RecombinationLine(PlasmaModel):
-    """
+    r"""
     Emitter that calculates spectral line emission from a plasma object
     as a result of dielectronic recombination of the target species.
 
     .. math::
-        \\epsilon_{\\mathrm{recomb}}(\\lambda) = \\frac{1}{4 \\pi} n_{Z_\\mathrm{i} + 1} n_\\mathrm{e}
-        \\mathrm{PEC}_{\\mathrm{recomb}}(n_\\mathrm{e}, T_\\mathrm{e}) f(\\lambda),
+        \epsilon_{\mathrm{recomb}}(\lambda) = \frac{1}{4 \pi} n_{Z_\mathrm{i} + 1} n_\mathrm{e}
+        \mathrm{PEC}_{\mathrm{recomb}}(n_\mathrm{e}, T_\mathrm{e}) f(\lambda),
 
-    where :math:`n_{Z_\\mathrm{i} + 1}` is the recombining species density,
-    :math:`\\mathrm{PEC}_{\\mathrm{recomb}}` is the dielectronic recombination photon emission coefficient
-    for the specified spectral line of the :math:`Z_\\mathrm{i}` ion,
-    :math:`f(\\lambda)` is the normalised spectral line shape,
+    where :math:`n_{Z_\mathrm{i} + 1}` is the recombining species density,
+    :math:`\mathrm{PEC}_{\mathrm{recomb}}` is the dielectronic recombination photon emission coefficient
+    for the specified spectral line of the :math:`Z_\mathrm{i}` ion,
+    :math:`f(\lambda)` is the normalised spectral line shape,
 
     :param Line line: Spectroscopic emission line object.
     :param Plasma plasma: The plasma to which this emission model is attached. Default is None.

--- a/cherab/core/model/plasma/recombination.pyx
+++ b/cherab/core/model/plasma/recombination.pyx
@@ -23,6 +23,29 @@ from cherab.core.utility.constants cimport RECIP_4_PI
 
 
 cdef class RecombinationLine(PlasmaModel):
+    """
+    Emitter that calculates spectral line emission from a plasma object
+    as a result of dielectronic recombination of the target species.
+
+    .. math::
+        \\epsilon_{\\mathrm{recomb}}(\\lambda) = \\frac{1}{4 \\pi} n_{Z_\\mathrm{i} + 1} n_\\mathrm{e}
+        \\mathrm{PEC}_{\\mathrm{recomb}}(n_\\mathrm{e}, T_\\mathrm{e}) f(\\lambda),
+
+    where :math:`n_{Z_\\mathrm{i} + 1}` is the recombining species density,
+    :math:`\\mathrm{PEC}_{\\mathrm{recomb}}` is the dielectronic recombination photon emission coefficient
+    for the specified spectral line of the :math:`Z_\\mathrm{i}` ion,
+    :math:`f(\\lambda)` is the normalised spectral line shape,
+
+    :param Line line: Spectroscopic emission line object.
+    :param Plasma plasma: The plasma to which this emission model is attached. Default is None.
+    :param AtomicData atomic_data: The atomic data provider for this model. Default is None.
+    :param object lineshape: Line shape model class. Default is None (GaussianLine).
+    :param object lineshape_args: A list of line shape model arguments. Default is None.
+    :param object lineshape_kwargs: A dictionary of line shape model keyword arguments. Default is None.
+
+    :ivar Plasma plasma: The plasma to which this emission model is attached.
+    :ivar AtomicData atomic_data: The atomic data provider for this model.
+    """
 
     def __init__(self, Line line, Plasma plasma=None, AtomicData atomic_data=None, object lineshape=None,
                  object lineshape_args=None, object lineshape_kwargs=None):

--- a/docs/source/models/basic_line/basic_line_emission.rst
+++ b/docs/source/models/basic_line/basic_line_emission.rst
@@ -2,4 +2,6 @@
 Basic Line Emission
 ===================
 
-Documentation for this model will go here soon...
+.. autoclass:: cherab.core.model.plasma.impact_excitation.ExcitationLine
+
+.. autoclass:: cherab.core.model.plasma.recombination.RecombinationLine


### PR DESCRIPTION
This adds missing docstrings for `ExcitationLine` and `RecombinationLine` emission models. This was originally part of #386, but has been moved to a separate PR.