### PR TITLE
Fix SciPy cumtrapz deprecation warning

### DIFF
--- a/cherab/core/model/attenuator/singleray.pyx
+++ b/cherab/core/model/attenuator/singleray.pyx
@@ -18,7 +18,7 @@
 # See the Licence for the specific language governing permissions and limitations
 # under the Licence.
 
-from scipy.integrate import cumtrapz
+from scipy.integrate import cumulative_trapezoid
 import numpy as np
 cimport numpy as np
 
@@ -218,7 +218,7 @@ cdef class SingleRayAttenuator(BeamAttenuator):
         for i in range(naxis):
             stopping_coeff[i] = self._beam_stopping(x[i], y[i], z[i], beam_velocity)
 
-        return beam_density * np.exp(-cumtrapz(stopping_coeff, axis, initial=0.0) / speed)
+        return beam_density * np.exp(-cumulative_trapezoid(stopping_coeff, axis, initial=0) / speed)
 
     @cython.cdivision(True)
     cdef double _beam_stopping(self, double x, double y, double z, Vector3D beam_velocity):

--- a/cherab/core/model/attenuator/singleray.pyx
+++ b/cherab/core/model/attenuator/singleray.pyx
@@ -18,7 +18,11 @@
 # See the Licence for the specific language governing permissions and limitations
 # under the Licence.
 
-from scipy.integrate import cumulative_trapezoid
+try:
+    from scipy.integrate import cumulative_trapezoid
+except ImportError:
+    from scipy.integrate import cumtrapz as cumulative_trapezoid
+
 import numpy as np
 cimport numpy as np
 


### PR DESCRIPTION
This PR fixes SciPy `DeprecationWarning` (#436):
```
DeprecationWarning: 'scipy.integrate.cumtrapz' is deprecated in favour of 'scipy.integrate.cumulative_trapezoid' and will be removed in SciPy 1.14.0
```
when performing any calculations with the `Beam` object configured to use `SingleRayAttenuator`.