### PR TITLE
Restrict the version of NumPy to 1.x until Raysect binaries built with NumPy 2 are available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        numpy-version: ["oldest-supported-numpy", "numpy"]
+        numpy-version: ["oldest-supported-numpy", "'numpy<2'"]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
     - name: Checkout code
@@ -23,7 +23,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Python dependencies
-      run: python -m pip install --prefer-binary cython>=0.28 "${{ matrix.numpy-version }}<2.0" scipy matplotlib "pyopencl[pocl]>=2022.2.4"
+      run: python -m pip install --prefer-binary cython>=0.28 ${{ matrix.numpy-version }} scipy matplotlib "pyopencl[pocl]>=2022.2.4"
     - name: Install Raysect from pypi
       run: pip install raysect==0.8.1
     - name: Build cherab

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Python dependencies
-      run: python -m pip install --prefer-binary cython>=0.28 ${{ matrix.numpy-version }} scipy matplotlib "pyopencl[pocl]>=2022.2.4"
+      run: python -m pip install --prefer-binary cython>=0.28 "${{ matrix.numpy-version }}<2.0" scipy matplotlib "pyopencl[pocl]>=2022.2.4"
     - name: Install Raysect from pypi
       run: pip install raysect==0.8.1
     - name: Build cherab

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cython>=0.28
-numpy>=1.14
+numpy>=1.14,<2.0
 scipy
 matplotlib
 raysect==0.8.1

--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     install_requires=[
-        "numpy>=1.14",
+        "numpy>=1.14,<2.0",
         "scipy",
         "matplotlib",
         "raysect==0.8.1",


### PR DESCRIPTION
This fixes #442 by restricting the required NumPy version to 1.x.