### PR TITLE
Tests: Move Plasma and Beam set up into the setUp() method

### DIFF
--- a/cherab/core/tests/test_beam.py
+++ b/cherab/core/tests/test_beam.py
@@ -55,32 +55,38 @@ class MockAtomicData(AtomicData):
 
 class TestBeam(unittest.TestCase):
 
-    atomic_data = MockAtomicData()
+    def setUp(self):
 
-    world = World()
+        self.atomic_data = MockAtomicData()
 
-    plasma_density = 1.e19
-    plasma_temperature = 1.e3
-    plasma_species = [(deuterium, 1, plasma_density, plasma_temperature, Vector3D(0, 0, 0))]
-    plasma = build_constant_slab_plasma(length=1, width=1, height=1, electron_density=plasma_density,
-                                        electron_temperature=plasma_temperature,
-                                        plasma_species=plasma_species)
-    plasma.atomic_data = atomic_data
-    plasma.parent = world
+        self.world = World()
 
-    beam = Beam(transform=translate(0.5, 0, 0))
-    beam.atomic_data = atomic_data
-    beam.plasma = plasma
-    beam.attenuator = SingleRayAttenuator(clamp_to_zero=True)
-    beam.energy = 50000
-    beam.power = 1e6
-    beam.temperature = 10
-    beam.element = deuterium
-    beam.parent = world
-    beam.sigma = 0.2
-    beam.divergence_x = 1.
-    beam.divergence_y = 2.
-    beam.length = 10.
+        self.plasma_density = 1.e19
+        self.plasma_temperature = 1.e3
+        plasma_species = [(deuterium, 1, self.plasma_density, self.plasma_temperature, Vector3D(0, 0, 0))]
+        plasma = build_constant_slab_plasma(length=1, width=1, height=1,
+                                            electron_density=self.plasma_density,
+                                            electron_temperature=self.plasma_temperature,
+                                            plasma_species=plasma_species)
+        plasma.atomic_data = self.atomic_data
+        plasma.parent = self.world
+
+        beam = Beam(transform=translate(0.5, 0, 0))
+        beam.atomic_data = self.atomic_data
+        beam.plasma = plasma
+        beam.attenuator = SingleRayAttenuator(clamp_to_zero=True)
+        beam.energy = 50000
+        beam.power = 1e6
+        beam.temperature = 10
+        beam.element = deuterium
+        beam.parent = self.world
+        beam.sigma = 0.2
+        beam.divergence_x = 1.
+        beam.divergence_y = 2.
+        beam.length = 10.
+
+        self.plasma = plasma
+        self.beam = beam
 
     def test_beam_density(self):
 

--- a/cherab/core/tests/test_beamcxline.py
+++ b/cherab/core/tests/test_beamcxline.py
@@ -76,25 +76,33 @@ class MockAtomicData(AtomicData):
 
 class TestBeamCXLine(unittest.TestCase):
 
-    world = World()
+    def setUp(self):
 
-    atomic_data = MockAtomicData()
+        self.world = World()
 
-    plasma_species = [(deuterium, 1, 1.e19, 200., Vector3D(0, 0, 0))]
-    plasma = build_constant_slab_plasma(length=1, width=1, height=1, electron_density=1e19, electron_temperature=200.,
-                                        plasma_species=plasma_species, b_field=Vector3D(0, 10., 0))
-    plasma.atomic_data = atomic_data
-    plasma.parent = world
+        self.atomic_data = MockAtomicData()
 
-    beam = Beam(transform=translate(0.5, 0, 0))
-    beam.atomic_data = atomic_data
-    beam.plasma = plasma
-    beam.attenuator = SingleRayAttenuator(clamp_to_zero=True)
-    beam.energy = 50000
-    beam.power = 1e6
-    beam.temperature = 10
-    beam.element = deuterium
-    beam.parent = world
+        plasma_species = [(deuterium, 1, 1.e19, 200., Vector3D(0, 0, 0))]
+        plasma = build_constant_slab_plasma(length=1, width=1, height=1,
+                                            electron_density=1e19,
+                                            electron_temperature=200.,
+                                            plasma_species=plasma_species,
+                                            b_field=Vector3D(0, 10., 0))
+        plasma.atomic_data = self.atomic_data
+        plasma.parent = self.world
+
+        beam = Beam(transform=translate(0.5, 0, 0))
+        beam.atomic_data = self.atomic_data
+        beam.plasma = plasma
+        beam.attenuator = SingleRayAttenuator(clamp_to_zero=True)
+        beam.energy = 50000
+        beam.power = 1e6
+        beam.temperature = 10
+        beam.element = deuterium
+        beam.parent = self.world
+
+        self.plasma = plasma
+        self.beam = beam
 
     def test_default_lineshape(self):
         # setting up the model

--- a/cherab/core/tests/test_bremsstrahlung.py
+++ b/cherab/core/tests/test_bremsstrahlung.py
@@ -34,13 +34,18 @@ import scipy.constants as const
 
 class TestBremsstrahlung(unittest.TestCase):
 
-    world = World()
+    def setUp(self):
 
-    plasma_species = [(deuterium, 1, 1.e19, 2000., Vector3D(0, 0, 0)), (nitrogen, 7, 1.e18, 2000., Vector3D(0, 0, 0))]
-    plasma = build_constant_slab_plasma(length=1, width=1, height=1, electron_density=1e19, electron_temperature=2000.,
-                                        plasma_species=plasma_species)
-    plasma.parent = world
-    plasma.atomic_data = AtomicData()
+        self.world = World()
+
+        plasma_species = [(deuterium, 1, 1.e19, 2000., Vector3D(0, 0, 0)),
+                          (nitrogen, 7, 1.e18, 2000., Vector3D(0, 0, 0))]
+        self.plasma = build_constant_slab_plasma(length=1, width=1, height=1,
+                                                 electron_density=1e19,
+                                                 electron_temperature=2000.,
+                                                 plasma_species=plasma_species)
+        self.plasma.parent = self.world
+        self.plasma.atomic_data = AtomicData()
 
     def test_bremsstrahlung_model(self):
         # setting up the model

--- a/cherab/core/tests/test_lineshapes.py
+++ b/cherab/core/tests/test_lineshapes.py
@@ -42,10 +42,15 @@ HC_EV_NM = 1239.8419738620933  # (Planck constant in eV s) x (speed of light in 
 
 class TestLineShapes(unittest.TestCase):
 
-    plasma_species = [(deuterium, 0, 1.e18, 5., Vector3D(2.e4, 0, 0)),
-                      (nitrogen, 1, 1.e17, 10., Vector3D(1.e4, 5.e4, 0))]
-    plasma = build_constant_slab_plasma(length=1, width=1, height=1, electron_density=1e19, electron_temperature=20.,
-                                        plasma_species=plasma_species, b_field=Vector3D(0, 5., 0))
+    def setUp(self):
+
+        plasma_species = [(deuterium, 0, 1.e18, 5., Vector3D(2.e4, 0, 0)),
+                          (nitrogen, 1, 1.e17, 10., Vector3D(1.e4, 5.e4, 0))]
+        self.plasma = build_constant_slab_plasma(length=1, width=1, height=1,
+                                                 electron_density=1e19,
+                                                 electron_temperature=20.,
+                                                 plasma_species=plasma_species,
+                                                 b_field=Vector3D(0, 5., 0))
 
     def test_gaussian_line(self):
         # setting up a line shape model


### PR DESCRIPTION
This fixes #448 by moving the creation and configuration of the `Plasma` and `Beam` to the `setUp()` method in the `TestBeam`, `TestBeamCXLine`, `TestBremsstrahlung` and `TestLineShapes` test cases.