### PR TITLE
Improve and expand the documentation for the atomic data repository

### DIFF
--- a/cherab/openadas/install.py
+++ b/cherab/openadas/install.py
@@ -269,14 +269,17 @@ def install_adf15(element, ionisation, file_path, download=False, repository_pat
 
 
 def install_adf21(beam_species, target_ion, target_charge, file_path, download=False, repository_path=None, adas_path=None):
-    # """
-    # Adds the rate defined in an ADF21 file to the repository.
-    #
-    # :param file_path: Path relative to ADAS root.
-    # :param download: Attempt to download file if not present (Default=True).
-    # :param repository_path: Path to the repository in which to install the rates (optional).
-    # :param adas_path: Path to ADAS files repository (optional).
-    # """
+    """
+    Adds the beam stopping rate defined in an ADF21 file to the repository.
+
+    :param beam_species: Beam neutral atom (Element/Isotope).
+    :param target_ion: Target species (Element/Isotope).
+    :param target_charge: Charge of the target species.
+    :param file_path: Path relative to ADAS root.
+    :param download: Attempt to download file if not present (Default=True).
+    :param repository_path: Path to the repository in which to install the rates (optional).
+    :param adas_path: Path to ADAS files repository (optional).
+    """
 
     print('Installing {}...'.format(file_path))
     path = _locate_adas_file(file_path, download, adas_path, repository_path)
@@ -289,15 +292,18 @@ def install_adf21(beam_species, target_ion, target_charge, file_path, download=F
 
 
 def install_adf22bmp(beam_species, beam_metastable, target_ion, target_charge, file_path, download=False, repository_path=None, adas_path=None):
-    pass
-    # """
-    # Adds the rate defined in an ADF21 file to the repository.
-    #
-    # :param file_path: Path relative to ADAS root.
-    # :param download: Attempt to download file if not present (Default=True).
-    # :param repository_path: Path to the repository in which to install the rates (optional).
-    # :param adas_path: Path to ADAS files repository (optional).
-    # """
+    """
+    Adds the beam population rate defined in an ADF22 BMP file to the repository.
+
+    :param beam_species: Beam neutral atom (Element/Isotope).
+    :param beam_metastable: Metastable/excitation level of beam neutral atom.
+    :param target_ion: Target species (Element/Isotope).
+    :param target_charge: Charge of the target species.
+    :param file_path: Path relative to ADAS root.
+    :param download: Attempt to download file if not present (Default=True).
+    :param repository_path: Path to the repository in which to install the rates (optional).
+    :param adas_path: Path to ADAS files repository (optional).
+    """
 
     print('Installing {}...'.format(file_path))
     path = _locate_adas_file(file_path, download, adas_path, repository_path)
@@ -310,15 +316,18 @@ def install_adf22bmp(beam_species, beam_metastable, target_ion, target_charge, f
 
 
 def install_adf22bme(beam_species, target_ion, target_charge, transition, file_path, download=False, repository_path=None, adas_path=None):
-    pass
-    # """
-    # Adds the rate defined in an ADF21 file to the repository.
-    #
-    # :param file_path: Path relative to ADAS root.
-    # :param download: Attempt to download file if not present (Default=True).
-    # :param repository_path: Path to the repository in which to install the rates (optional).
-    # :param adas_path: Path to ADAS files repository (optional).
-    # """
+    """
+    Adds the beam emission rate defined in an ADF22 BME file to the repository.
+
+    :param beam_species: Beam neutral atom (Element/Isotope).
+    :param target_ion: Target species (Element/Isotope).
+    :param target_charge: Charge of the target species.
+    :param transition: Tuple containing (initial level, final level).
+    :param file_path: Path relative to ADAS root.
+    :param download: Attempt to download file if not present (Default=True).
+    :param repository_path: Path to the repository in which to install the rates (optional).
+    :param adas_path: Path to ADAS files repository (optional).
+    """
 
     print('Installing {}...'.format(file_path))
     path = _locate_adas_file(file_path, download, adas_path, repository_path)

--- a/cherab/openadas/repository/atomic.py
+++ b/cherab/openadas/repository/atomic.py
@@ -1,6 +1,6 @@
-# Copyright 2016-2018 Euratom
-# Copyright 2016-2018 United Kingdom Atomic Energy Authority
-# Copyright 2016-2018 Centro de Investigaciones Energéticas, Medioambientales y Tecnológicas
+# Copyright 2016-2024 Euratom
+# Copyright 2016-2024 United Kingdom Atomic Energy Authority
+# Copyright 2016-2024 Centro de Investigaciones Energéticas, Medioambientales y Tecnológicas
 #
 # Licensed under the EUPL, Version 1.1 or – as soon they will be approved by the
 # European Commission - subsequent versions of the EUPL (the "Licence");
@@ -34,8 +34,15 @@ def add_ionisation_rate(species, charge, rate, repository_path=None):
     function instead. The update function avoids repeatedly opening and closing
     the rate files.
 
-    :param repository_path:
-    :return:
+    :param species: Plasma species (Element/Isotope).
+    :param charge: Charge of the plasma species.
+    :param rate: Ionisation rate dictionary containing the following entries:
+
+    |      'ne': array-like of size (N) with electron density in m^-3,
+    |      'te': array-like of size (M) with electron temperature in eV,
+    |      'rate': array-like of size (N, M) with ionisation rate in m^3.s^-1.
+
+    :param repository_path: Path to the atomic data repository.
     """
 
     update_ionisation_rates({
@@ -47,11 +54,21 @@ def add_ionisation_rate(species, charge, rate, repository_path=None):
 
 def update_ionisation_rates(rates, repository_path=None):
     """
-    Ionisation rate file structure
-
-    /ionisation/<species>.json
+    Updates the ionisation rate files `/ionisation/<species>.json`
+    in atomic data repository.
 
     File contains multiple rates, indexed by the ion charge state.
+
+    :param rates: Dictionary in the form {<species>: {<charge>: <rate>}}, where
+
+    |      <species> is the plasma species (Element/Isotope),
+    |      <charge> is the charge of the plasma species,
+    |      <rate> is the ionisation rate dictionary containing the following entries:
+    |          'ne': array-like of size (N) with electron density in m^-3,
+    |          'te': array-like of size (M) with electron temperature in eV,
+    |          'rate': array-like of size (N, M) with ionisation rate in m^3.s^-1.
+
+    :param repository_path: Path to the atomic data repository.
     """
 
     repository_path = repository_path or DEFAULT_REPOSITORY_PATH
@@ -75,8 +92,15 @@ def add_recombination_rate(species, charge, rate, repository_path=None):
     function instead. The update function avoids repeatedly opening and closing
     the rate files.
 
-    :param repository_path:
-    :return:
+    :param species: Plasma species (Element/Isotope).
+    :param charge: Charge of the plasma species.
+    :param rate: Recombination rate dictionary containing the following entries:
+
+    |      'ne': array-like of size (N) with electron density in m^-3,
+    |      'te': array-like of size (M) with electron temperature in eV,
+    |      'rate': array-like of size (N, M) with recombination rate in m^3.s^-1.
+
+    :param repository_path: Path to the atomic data repository.
     """
 
     update_recombination_rates({
@@ -88,11 +112,21 @@ def add_recombination_rate(species, charge, rate, repository_path=None):
 
 def update_recombination_rates(rates, repository_path=None):
     """
-    Ionisation rate file structure
-
-    /recombination/<species>.json
+    Updates the recombination rate files `/recombination/<species>.json`
+    in the atomic data repository.
 
     File contains multiple rates, indexed by the ion charge state.
+
+    :param rates: Dictionary in the form {<species>: {<charge>: <rate>}}, where
+
+    |      <species> is the plasma species (Element/Isotope),
+    |      <charge> is the charge of the plasma species,
+    |      <rate> is the recombination rate dictionary containing the following entries:
+    |          'ne': array-like of size (N) with electron density in m^-3,
+    |          'te': array-like of size (M) with electron temperature in eV,
+    |          'rate': array-like of size (N, M) with recombination rate in m^3.s^-1.
+
+    :param repository_path: Path to the atomic data repository.
     """
 
     repository_path = repository_path or DEFAULT_REPOSITORY_PATH
@@ -109,7 +143,6 @@ def update_recombination_rates(rates, repository_path=None):
 
 
 def add_thermal_cx_rate(donor_element, donor_charge, receiver_element, rate, repository_path=None):
-
     """
     Adds a single thermal charge exchange rate to the repository.
 
@@ -118,11 +151,16 @@ def add_thermal_cx_rate(donor_element, donor_charge, receiver_element, rate, rep
     the rate files.
 
     :param donor_element: Element donating the electron.
-    :param donor_charge: Charge of the donating atom/ion
-    :param receiver_element: Element receiving the electron
-    :param rate: rates
-    :param repository_path:
-    :return:
+    :param donor_charge: Charge of the donating atom/ion.
+    :param receiver_element: Element receiving the electron.
+    :param receiver_charge: Charge of the receiving atom/ion.
+    :param rate: Thermal CX rate dictionary containing the following entries:
+
+    |      'ne': array-like of size (N) with electron density in m^-3,
+    |      'te': array-like of size (M) with electron temperature in eV,
+    |      'rate': array-like of size (N, M) with thermal CX rate in m^3.s^-1.
+
+    :param repository_path: Path to the atomic data repository.
     """
 
     rates2update = RecursiveDict()
@@ -133,11 +171,25 @@ def add_thermal_cx_rate(donor_element, donor_charge, receiver_element, rate, rep
 
 def update_thermal_cx_rates(rates, repository_path=None):
     """
-    Thermal charge exchange rate file structure
-
-    /thermal_cx/<donor_element>/<donor_charge>/<receiver_element>.json
+    Updates the thermal charge exchange rate files
+    `/thermal_cx/<donor_element>/<donor_charge>/<receiver_element>.json`
+    in the atomic data repository.
 
     File contains multiple rates, indexed by the ion charge state.
+
+    :param rates: Dictionary in the form:
+
+    |  { <donor_element>: { <donor_charge>: { <receiver_element>: { <donor_charge>: <rate> } } } }, where
+    |      <donor_element> is the element donating the electron.
+    |      <donor_charge> is the charge of the donating atom/ion.
+    |      <receiver_element> is the element receiving the electron.
+    |      <receiver_charge> is the charge of the receiving atom/ion.
+    |      <rate> is the thermal CX rate dictionary containing the following entries:
+    |          'ne': array-like of size (N) with electron density in m^-3,
+    |          'te': array-like of size (M) with electron temperature in eV,
+    |          'rate': array-like of size (N, M) with thermal CX rate in m^3.s^-1.
+
+    :param repository_path: Path to the atomic data repository.
     """
 
     repository_path = repository_path or DEFAULT_REPOSITORY_PATH
@@ -203,6 +255,21 @@ def _update_and_write_adf11(species, rate_data, path):
 
 
 def get_ionisation_rate(element, charge, repository_path=None):
+    """
+    Reads the ionisation rate for the given species and charge
+    from the atomic data repository.
+
+    :param element: Plasma species (Element/Isotope).
+    :param charge: Charge of the plasma species.
+    :param repository_path: Path to the atomic data repository.
+
+    :return rate: Ionisation rate dictionary containing the following entries:
+
+    |      'ne': 1D array of size (N) with electron density in m^-3,
+    |      'te': 1D array of size (M) with electron temperature in eV,
+    |      'rate': 2D array of size (N, M) with ionisation rate in m^3.s^-1.
+
+    """
 
     repository_path = repository_path or DEFAULT_REPOSITORY_PATH
 
@@ -224,6 +291,21 @@ def get_ionisation_rate(element, charge, repository_path=None):
 
 
 def get_recombination_rate(element, charge, repository_path=None):
+    """
+    Reads the recombination rate for the given species and charge
+    from the atomic data repository.
+
+    :param element: Plasma species (Element/Isotope).
+    :param charge: Charge of the plasma species.
+    :param repository_path: Path to the atomic data repository.
+
+    :return rate: Recombination rate dictionary containing the following entries:
+
+    |      'ne': 1D array of size (N) with electron density in m^-3,
+    |      'te': 1D array of size (M) with electron temperature in eV,
+    |      'rate': 2D array of size (N, M) with recombination rate in m^3.s^-1.
+
+    """
 
     repository_path = repository_path or DEFAULT_REPOSITORY_PATH
 
@@ -245,6 +327,23 @@ def get_recombination_rate(element, charge, repository_path=None):
 
 
 def get_thermal_cx_rate(donor_element, donor_charge, receiver_element, receiver_charge, repository_path=None):
+    """
+    Reads the thermal charge exchange rate for the given species and charge
+    from the atomic data repository.
+
+    :param donor_element: Element donating the electron.
+    :param donor_charge: Charge of the donating atom/ion.
+    :param receiver_element: Element receiving the electron.
+    :param receiver_charge: Charge of the receiving atom/ion.
+    :param repository_path: Path to the atomic data repository.
+
+    :return rate: Thermal CX rate dictionary containing the following entries:
+
+    |      'ne': 1D array of size (N) with electron density in m^-3,
+    |      'te': 1D array of size (M) with electron temperature in eV,
+    |      'rate': 2D array of size (N, M) with thermal CX rate in m^3.s^-1.
+
+    """
 
     repository_path = repository_path or DEFAULT_REPOSITORY_PATH
 

--- a/cherab/openadas/repository/beam/emission.py
+++ b/cherab/openadas/repository/beam/emission.py
@@ -1,6 +1,6 @@
-# Copyright 2016-2018 Euratom
-# Copyright 2016-2018 United Kingdom Atomic Energy Authority
-# Copyright 2016-2018 Centro de Investigaciones Energéticas, Medioambientales y Tecnológicas
+# Copyright 2016-2024 Euratom
+# Copyright 2016-2024 United Kingdom Atomic Energy Authority
+# Copyright 2016-2024 Centro de Investigaciones Energéticas, Medioambientales y Tecnológicas
 #
 # Licensed under the EUPL, Version 1.1 or – as soon they will be approved by the
 # European Commission - subsequent versions of the EUPL (the "Licence");
@@ -36,8 +36,24 @@ def add_beam_emission_rate(beam_species, target_ion, target_charge, transition, 
     function instead. The update function avoid repeatedly opening and closing
     the rate files.
 
-    :param repository_path:
-    :return:
+    :param beam_species: Beam neutral species (Element/Isotope).
+    :param target_ion: Target species (Element/Isotope).
+    :param target_charge: Charge of the target species.
+    :param transition: Tuple containing (initial level, final level).
+    :param rate: Beam emission rate dictionary containing the following entries:
+
+    |      'e': array-like of size (N) with interaction energy in eV/amu,
+    |      'n' array-like of size (M) with target electron density in m^-3,
+    |      't' array-like of size (K) with target electron temperature in eV,
+    |      'sen' array-like of size (N, M) with beam emission rate energy component in photon.m^3.s^-1.
+    |      'st' array-like of size (K) with beam emission rate temperature component in photon.m^3.s^-1.
+    |      'eref': reference interaction energy in eV/amu,
+    |      'nref': reference target electron density in m^-3,
+    |      'tref': reference target electron temperature in eV,
+    |      'sref': reference beam emission rate in photon.m^3.s^-1.
+    |  The total beam emission rate: s = sen * st / sref.
+
+    :param repository_path: Path to the atomic data repository.
     """
 
     update_beam_emission_rates({
@@ -53,11 +69,32 @@ def add_beam_emission_rate(beam_species, target_ion, target_charge, transition, 
 
 def update_beam_emission_rates(rates, repository_path=None):
     """
-    Beam emission rate file structure
-
+    Updates the beam emission rate files:
     /beam/emission/<beam species>/<target ion>/<target_charge>.json
+    in the atomic repository.
 
     File contains multiple rates, indexed by transition.
+
+    :param rates: Dictionary in the form:
+
+    |  { <beam_species>: { <target_ion>: { <target_charge>: {<transition>: <rate>} } } }, where
+    |      <beam_species> is the beam neutral species (Element/Isotope)
+    |      <target_ion> is the target species (Element/Isotope).
+    |      <target_charge> is the charge of the target species.
+    |      <transition> is the tuple containing (initial level, final level).
+    |      <rate> Beam emission rate dictionary containing the following entries:
+    |          'e': array-like of size (N) with interaction energy in eV/amu,
+    |          'n' array-like of size (M) with target electron density in m^-3,
+    |          't' array-like of size (K) with target electron temperature in eV,
+    |          'sen' array-like of size (N, M) with beam emission rate energy component in photon.m^3.s^-1.
+    |          'st' array-like of size (K) with beam emission rate temperature component in photon.m^3.s^-1.
+    |          'eref': reference interaction energy in eV/amu,
+    |          'nref': reference target electron density in m^-3,
+    |          'tref': reference target electron temperature in eV,
+    |          'sref': reference beam emission rate in photon.m^3.s^-1.
+    |      The total beam emission rate: s = sen * st / sref.
+
+    :param repository_path: Path to the atomic data repository.
     """
 
     repository_path = repository_path or DEFAULT_REPOSITORY_PATH
@@ -136,6 +173,29 @@ def update_beam_emission_rates(rates, repository_path=None):
 
 
 def get_beam_emission_rate(beam_species, target_ion, target_charge, transition, repository_path=None):
+    """
+    Reads a single beam emission rate from the repository.
+
+    :param beam_species: Beam neutral species (Element/Isotope).
+    :param target_ion: Target species (Element/Isotope).
+    :param target_charge: Charge of the target species.
+    :param transition: Tuple containing (initial level, final level).
+    :param repository_path: Path to the atomic data repository.
+
+    :return rate: Beam emission rate dictionary containing the following entries:
+
+    |      'e': 1D array of size (N) with interaction energy in eV/amu,
+    |      'n' 1D array of size (M) with target electron density in m^-3,
+    |      't' 1D array of size (K) with target electron temperature in eV,
+    |      'sen' 2D array of size (N, M) with beam emission rate energy component in photon.m^3.s^-1.
+    |      'st' 1D array of size (K) with beam emission rate temperature component in photon.m^3.s^-1.
+    |      'eref': reference interaction energy in eV/amu,
+    |      'nref': reference target electron density in m^-3,
+    |      'tref': reference target electron temperature in eV,
+    |      'sref': reference beam emission rate in photon.m^3.s^-1.
+    |  The total beam emission rate: s = sen * st / sref.
+
+    """
 
     repository_path = repository_path or DEFAULT_REPOSITORY_PATH
     path = os.path.join(repository_path, 'beam/emission/{}/{}/{}.json'.format(beam_species.symbol.lower(), target_ion.symbol.lower(), target_charge))

--- a/cherab/openadas/repository/beam/population.py
+++ b/cherab/openadas/repository/beam/population.py
@@ -31,12 +31,24 @@ def add_beam_population_rate(beam_species, beam_metastable, target_ion, target_c
     """
     Adds a single beam population rate to the repository.
 
-    :param beam_species:
-    :param beam_metastable:
-    :param target_ion:
-    :param target_charge:
-    :param rate:
-    :return:
+    :param beam_species: Beam neutral species (Element/Isotope).
+    :param beam_metastable: Metastable level of beam neutral atom.
+    :param target_ion: Target species (Element/Isotope).
+    :param target_charge: Charge of the target species.
+    :param rate: Beam population rate dictionary containing the following entries:
+
+    |      'e': array-like of size (N) with interaction energy in eV/amu,
+    |      'n': array-like of size (M) with target electron density in m^-3,
+    |      't': array-like of size (K) with target electron temperature in eV,
+    |      'sen': array-like of size (N, M) with dimensionless beam population rate energy component.
+    |      'st': array-like of size (K) with dimensionless beam population rate temperature component.
+    |      'eref': reference interaction energy in eV/amu,
+    |      'nref': reference target electron density in m^-3,
+    |      'tref': reference target electron temperature in eV,
+    |      'sref': reference dimensionless beam population rate.
+    |  The total beam population rate: s = sen * st / sref.
+
+    :param repository_path: Path to the atomic data repository.
     """
 
     repository_path = repository_path or DEFAULT_REPOSITORY_PATH
@@ -102,11 +114,32 @@ def add_beam_population_rate(beam_species, beam_metastable, target_ion, target_c
 
 def update_beam_population_rates(rates, repository_path=None):
     """
-    Beam population rate file structure
-
+    Updates the beam population rate files
     /beam/population/<beam species>/<beam metastable>/<target ion>/<target_charge>.json
+    in the atomic data repository.
 
     Each json file contains a single rate, so it can simply be replaced.
+
+    :param rates: Dictionary in the form:
+
+    |  { <beam_species>: { <beam_metastable>: { <target_ion>: {<target_charge>: <rate>} } } }, where
+    |      <beam_species> is the beam neutral species (Element/Isotope)
+    |      <beam_metastable> is the metastable level of beam neutral atom.
+    |      <target_ion> is the target species (Element/Isotope).
+    |      <target_charge> is the charge of the target species.
+    |      <rate> is the beam population rate dictionary containing the following fields:
+    |          'e': array-like of size (N) with interaction energy in eV/amu,
+    |          'n': array-like of size (M) with target electron density in m^-3,
+    |          't': array-like of size (K) with target electron temperature in eV,
+    |          'sen': array-like of size (N, M) with dimensionless beam population rate energy component.
+    |          'st': array-like of size (K) with dimensionless beam population rate temperature component.
+    |          'eref': reference interaction energy in eV/amu,
+    |          'nref': reference target electron density in m^-3,
+    |          'tref': reference target electron temperature in eV,
+    |          'sref': reference dimensionless beam population rate.
+    |      The total beam population rate: s = sen * st / sref.
+
+    :param repository_path: Path to the atomic data repository.
     """
 
     for beam_species, beam_metastables in rates.items():
@@ -117,6 +150,29 @@ def update_beam_population_rates(rates, repository_path=None):
 
 
 def get_beam_population_rate(beam_species, beam_metastable, target_ion, target_charge, repository_path=None):
+    """
+    Reads a single beam population rate from the repository.
+
+    :param beam_species: Beam neutral species (Element/Isotope).
+    :param beam_metastable: Metastable level of beam neutral atom.
+    :param target_ion: Target species (Element/Isotope).
+    :param target_charge: Charge of the target species.
+    :param repository_path: Path to the atomic data repository.
+
+    :return rate: Beam population rate dictionary containing the following entries:
+
+    |      'e': 1D array of size (N) with interaction energy in eV/amu,
+    |      'n': 1D array of size (M) with target electron density in m^-3,
+    |      't': 1D array of size (K) with target electron temperature in eV,
+    |      'sen': 2D array of size (N, M) with dimensionless beam population rate energy component.
+    |      'st': 1D array of size (K) with dimensionless beam population rate temperature component.
+    |      'eref': reference interaction energy in eV/amu,
+    |      'nref': reference target electron density in m^-3,
+    |      'tref': reference target electron temperature in eV,
+    |      'sref': reference dimensionless beam population rate.
+    |  The total beam population rate: s = sen * st / sref.
+
+    """
 
     repository_path = repository_path or DEFAULT_REPOSITORY_PATH
     path = os.path.join(repository_path, 'beam/population/{}/{}/{}/{}.json'.format(beam_species.symbol.lower(), beam_metastable, target_ion.symbol.lower(), target_charge))

--- a/cherab/openadas/repository/beam/stopping.py
+++ b/cherab/openadas/repository/beam/stopping.py
@@ -31,11 +31,23 @@ def add_beam_stopping_rate(beam_species, target_ion, target_charge, rate, reposi
     """
     Adds a single beam stopping/excitation rate to the repository.
 
-    :param beam_species:
-    :param target_ion:
-    :param target_charge:
-    :param rate:
-    :return:
+    :param beam_species: Beam neutral atom (Element/Isotope).
+    :param target_ion: Target species (Element/Isotope).
+    :param target_charge: Charge of the target species.
+    :param rate: Beam stopping rate dictionary containing the following entries:
+
+    |      'e': array-like of size (N) with interaction energy in eV/amu,
+    |      'n': array-like of size (M) with target electron density in m^-3,
+    |      't': array-like of size (K) with target electron temperature in eV,
+    |      'sen': array-like of size (N, M) with beam stopping rate energy component in m^3.s^-1.
+    |      'st': array-like of size (K) with beam stopping rate temperature component in m^3.s^-1.
+    |      'eref': reference interaction energy in eV/amu,
+    |      'nref': reference target electron density in m^-3,
+    |      'tref': reference target electron temperature in eV,
+    |      'sref': reference beam stopping rate in m^3.s^-1.
+    |  The total beam stopping rate: s = sen * st / sref.
+
+    :param repository_path: Path to the atomic data repository.
     """
 
     repository_path = repository_path or DEFAULT_REPOSITORY_PATH
@@ -98,11 +110,30 @@ def add_beam_stopping_rate(beam_species, target_ion, target_charge, rate, reposi
 
 def update_beam_stopping_rates(rates, repository_path=None):
     """
-    Beam stopping rate file structure
-
-    /beam/stopping/<beam species>/<target ion>/<target_charge>.json
+    Updates the beam stopping rate files
+    /beam/stopping/<beam species>/<beam metastable>/<target ion>/<target_charge>.json
+    in the atomic data repository.
 
     Each json file contains a single rate, so it can simply be replaced.
+
+    :param rates: Dictionary in the form:
+
+    |  { <beam_species>: { <beam_metastable>: { <target_ion>: {<target_charge>: <rate>} } } }, where
+    |      <beam_species> is the beam neutral species (Element/Isotope).
+    |      <target_ion> is the target species (Element/Isotope).
+    |      <target_charge> is the charge of the target species.
+    |      <rate> is the beam stopping rate dictionary containing the following entries:
+    |          'e': array-like of size (N) with interaction energy in eV/amu,
+    |          'n': array-like of size (M) with target electron density in m^-3,
+    |          't': array-like of size (K) with target electron temperature in eV,
+    |          'sen': array-like of size (N, M) with beam stopping rate energy component in m^3.s^-1.
+    |          'st': array-like of size (K) with beam stopping rate temperature component in m^3.s^-1.
+    |          'eref': reference interaction energy in eV/amu,
+    |          'nref': reference target electron density in m^-3,
+    |          'tref': reference target electron temperature in eV,
+    |          'sref': reference beam stopping rate in m^3.s^-1.
+    |      The total beam stopping rate: s = sen * st / sref.
+
     """
 
     for beam_species, target_ions in rates.items():
@@ -112,6 +143,28 @@ def update_beam_stopping_rates(rates, repository_path=None):
 
 
 def get_beam_stopping_rate(beam_species, target_ion, target_charge, repository_path=None):
+    """
+    Reads a single beam stopping/excitation rate from the repository.
+
+    :param beam_species: Beam neutral atom (Element/Isotope).
+    :param target_ion: Target species (Element/Isotope).
+    :param target_charge: Charge of the target species.
+    :param repository_path: Path to the atomic data repository.
+
+    :return rate: Beam stopping rate dictionary containing the following entries:
+
+    |      'e': 1D array of size (N) with interaction energy in eV/amu,
+    |      'n': 1D array of size (M) with target electron density in m^-3,
+    |      't': 1D array of size (K) with target electron temperature in eV,
+    |      'sen': 2D array of size (N, M) with beam stopping rate energy component in m^3.s^-1.
+    |      'st': 1D array of size (K) with beam stopping rate temperature component in m^3.s^-1.
+    |      'eref': reference interaction energy in eV/amu,
+    |      'nref': reference target electron density in m^-3,
+    |      'tref': reference target electron temperature in eV,
+    |      'sref': reference beam stopping rate in m^3.s^-1.
+    |  The total beam stopping rate: s = sen * st / sref.
+
+    """
 
     repository_path = repository_path or DEFAULT_REPOSITORY_PATH
     path = os.path.join(repository_path, 'beam/stopping/{}/{}/{}.json'.format(beam_species.symbol.lower(), target_ion.symbol.lower(), target_charge))

--- a/cherab/openadas/repository/pec.py
+++ b/cherab/openadas/repository/pec.py
@@ -1,6 +1,6 @@
-# Copyright 2016-2018 Euratom
-# Copyright 2016-2018 United Kingdom Atomic Energy Authority
-# Copyright 2016-2018 Centro de Investigaciones Energéticas, Medioambientales y Tecnológicas
+# Copyright 2016-2024 Euratom
+# Copyright 2016-2024 United Kingdom Atomic Energy Authority
+# Copyright 2016-2024 Centro de Investigaciones Energéticas, Medioambientales y Tecnológicas
 #
 # Licensed under the EUPL, Version 1.1 or – as soon they will be approved by the
 # European Commission - subsequent versions of the EUPL (the "Licence");
@@ -36,12 +36,16 @@ def add_pec_excitation_rate(element, charge, transition, rate, repository_path=N
     instead. The update function avoid repeatedly opening and closing the rate
     files.
 
-    :param element:
-    :param charge:
-    :param transition:
-    :param rate:
-    :param repository_path:
-    :return:
+    :param element: Plasma species (Element/Isotope).
+    :param charge: Charge of the plasma species.
+    :param transition: Tuple containing (initial level, final level).
+    :param rate: Excitation PEC dictionary containing the following entries:
+
+    |      'ne': array-like of size (N) with electron density in m^-3,
+    |      'te': array-like of size (M) with electron temperature in eV,
+    |      'rate': array-like of size (N, M) with excitation PEC in photon.m^3.s^-1.
+
+    :param repository_path: Path to the atomic data repository.
     """
 
     update_pec_rates({
@@ -63,12 +67,16 @@ def add_pec_recombination_rate(element, charge, transition, rate, repository_pat
     instead. The update function avoid repeatedly opening and closing the rate
     files.
 
-    :param element:
-    :param charge:
-    :param transition:
-    :param rate:
-    :param repository_path:
-    :return:
+    :param element: Plasma species (Element/Isotope).
+    :param charge: Charge of the plasma species.
+    :param transition: Tuple containing (initial level, final level).
+    :param rate: Recombination PEC dictionary containing the following entries:
+
+    |      'ne': array-like of size (N) with electron density in m^-3,
+    |      'te': array-like of size (M) with electron temperature in eV,
+    |      'rate': array-like of size (N, M) with recombination PEC in photon.m^3.s^-1.
+
+    :param repository_path: Path to the atomic data repository.
     """
 
     update_pec_rates({
@@ -84,18 +92,22 @@ def add_pec_recombination_rate(element, charge, transition, rate, repository_pat
 
 def add_pec_thermalcx_rate(element, charge, transition, rate, repository_path=None):
     """
-    Adds a single PEC thermalcx rate to the repository.
+    Adds a single PEC thermal charge exchange rate to the repository.
 
     If adding multiple rate, consider using the update_pec_rates() function
     instead. The update function avoid repeatedly opening and closing the rate
     files.
 
-    :param element:
-    :param charge:
-    :param transition:
-    :param rate:
-    :param repository_path:
-    :return:
+    :param element: Plasma species (Element/Isotope).
+    :param charge: Charge of the plasma species.
+    :param transition: Tuple containing (initial level, final level).
+    :param rate: Thermal CX PEC dictionary containing the following entries:
+
+    |      'ne': array-like of size (N) with electron density in m^-3,
+    |      'te': array-like of size (M) with electron temperature in eV,
+    |      'rate': array-like of size (N, M) with thermal CX PEC in photon.m^3.s^-1.
+
+    :param repository_path: Path to the atomic data repository.
     """
 
     update_pec_rates({
@@ -111,9 +123,24 @@ def add_pec_thermalcx_rate(element, charge, transition, rate, repository_path=No
 
 def update_pec_rates(rates, repository_path=None):
     """
-    PEC rate file structure
+    Updates the PEC files /pec/<class>/<element>/<charge>.json.
+    in the atomic data repository.
 
-    /pec/<class>/<element>/<charge>.json
+    File contains multiple PECs, indexed by the transition.
+
+    :param rates: Dictionary in the form:
+
+    |  { <class>: { <element>: { <charge>: { <transition>: <pec> } } } }, where
+    |      <class> is the one of the following PEC types: 'excitation', 'recombination', 'thermalcx'.
+    |      <element> is the plasma species (Element/Isotope).
+    |      <charge> is the charge of the plasma species.
+    |      <transition> is the tuple containing (initial level, final level).
+    |      <pec> is the PEC dictionary containing the following entries:
+    |          'ne': array-like of size (N) with electron density in m^-3,
+    |          'te': array-like of size (M) with electron temperature in eV,
+    |          'rate': array-like of size (N, M) with PEC in photon.m^3.s^-1.
+
+    :param repository_path: Path to the atomic data repository.
     """
 
     valid_classes = [
@@ -184,14 +211,64 @@ def update_pec_rates(rates, repository_path=None):
 
 
 def get_pec_excitation_rate(element, charge, transition, repository_path=None):
+    """
+    Reads the excitation PEC from the repository for the given
+    element, charge and transition.
+
+    :param element: Plasma species (Element/Isotope).
+    :param charge: Charge of the plasma species.
+    :param transition: Tuple containing (initial level, final level).
+    :param repository_path: Path to the atomic data repository.
+
+    :return rate: Excitation PEC dictionary containing the following entries:
+
+    |      'ne': 1D array of size (N) with electron density in m^-3,
+    |      'te': 1D array of size (M) with electron temperature in eV,
+    |      'rate': 2D array of size (N, M) with excitation PEC in photon.m^3.s^-1.
+
+    """
+
     return _get_pec_rate('excitation', element, charge, transition, repository_path)
 
 
 def get_pec_recombination_rate(element, charge, transition, repository_path=None):
+    """
+    Reads the recombination PEC from the repository for the given
+    element, charge and transition.
+
+    :param element: Plasma species (Element/Isotope).
+    :param charge: Charge of the plasma species.
+    :param transition: Tuple containing (initial level, final level).
+    :param repository_path: Path to the atomic data repository.
+
+    :return rate: Recombination PEC dictionary containing the following entries:
+
+    |      'ne': 1D array of size (N) with electron density in m^-3,
+    |      'te': 1D array of size (M) with electron temperature in eV,
+    |      'rate': 2D array of size (N, M) with recombination PEC in photon.m^3.s^-1.
+
+    """
+
     return _get_pec_rate('recombination', element, charge, transition, repository_path)
 
 
 def get_pec_thermalcx_rate(element, charge, transition, repository_path=None):
+    """
+    Reads the thermal charge exchange PEC from the repository for the given
+    element, charge and transition.
+
+    :param element: Plasma species (Element/Isotope).
+    :param charge: Charge of the plasma species.
+    :param transition: Tuple containing (initial level, final level).
+    :param repository_path: Path to the atomic data repository.
+
+    :return rate: Thermal CX PEC dictionary containing the following entries:
+
+    |      'ne': 1D array of size (N) with electron density in m^-3,
+    |      'te': 1D array of size (M) with electron temperature in eV,
+    |      'rate': 2D array of size (N, M) with thermal CX PEC in photon.m^3.s^-1.
+
+    """
     return _get_pec_rate('thermalcx', element, charge, transition, repository_path)
 
 

--- a/cherab/openadas/repository/radiated_power.py
+++ b/cherab/openadas/repository/radiated_power.py
@@ -1,7 +1,7 @@
 
-# Copyright 2016-2018 Euratom
-# Copyright 2016-2018 United Kingdom Atomic Energy Authority
-# Copyright 2016-2018 Centro de Investigaciones Energéticas, Medioambientales y Tecnológicas
+# Copyright 2016-2024 Euratom
+# Copyright 2016-2024 United Kingdom Atomic Energy Authority
+# Copyright 2016-2024 Centro de Investigaciones Energéticas, Medioambientales y Tecnológicas
 #
 # Licensed under the EUPL, Version 1.1 or – as soon they will be approved by the
 # European Commission - subsequent versions of the EUPL (the "Licence");
@@ -29,13 +29,21 @@ from .utility import DEFAULT_REPOSITORY_PATH, valid_charge
 
 def add_line_power_rate(species, charge, rate, repository_path=None):
     """
-    Adds a single LineRadiationPower rate to the repository.
+    Adds a single line radiated power rate to the repository.
 
     If adding multiple rates, consider using the update_line_power_rates()
     function instead. The update function avoids repeatedly opening and closing
     the rate files.
 
-    :param repository_path:
+    :param species: Plasma species (Element/Isotope).
+    :param charge: Charge of the plasma species.
+    :param rate: Line radiated power rate dictionary containing the following entries:
+
+    |      'ne': array-like of size (N) with electron density in m^-3,
+    |      'te': array-like of size (M) with electron temperature in eV,
+    |      'rate': array-like of size (N, M) with line radiated power rate in W.m^3.
+
+    :param repository_path: Path to the atomic data repository.
     """
 
     update_line_power_rates({
@@ -47,13 +55,22 @@ def add_line_power_rate(species, charge, rate, repository_path=None):
 
 def update_line_power_rates(rates, repository_path=None):
     """
-    Update the repository of LineRadiationPower rates.
-
-    LineRadiationPower rate file structure
-
+    Update the files for the line radiated power rates:
     /radiated_power/line/<species>.json
+    in the atomic data repository.
 
     File contains multiple rates, indexed by the ion's charge state.
+
+    :param rates: Dictionary in the form {<species>: {<charge>: <rate>}}, where
+
+    |      <species> is the plasma species (Element/Isotope),
+    |      <charge> is the charge of the plasma species,
+    |      <rate> is the line radiated rate dictionary containing the following entries:
+    |          'ne': array-like of size (N) with electron density in m^-3,
+    |          'te': array-like of size (M) with electron temperature in eV,
+    |          'rate': array-like of size (N, M) with line radiated power rate in W.m^3.
+
+    :param repository_path: Path to the atomic data repository.
     """
 
     repository_path = repository_path or DEFAULT_REPOSITORY_PATH
@@ -71,13 +88,21 @@ def update_line_power_rates(rates, repository_path=None):
 
 def add_continuum_power_rate(species, charge, rate, repository_path=None):
     """
-    Adds a single ContinuumPower rate to the repository.
+    Adds a single continuum power rate to the repository.
 
     If adding multiple rates, consider using the update_continuum_power_rates()
     function instead. The update function avoids repeatedly opening and closing
     the rate files.
 
-    :param repository_path:
+    :param species: Plasma species (Element/Isotope).
+    :param charge: Charge of the plasma species.
+    :param rate: Continuum power rate dictionary containing the following entries:
+
+    |      'ne': array-like of size (N) with electron density in m^-3,
+    |      'te': array-like of size (M) with electron temperature in eV,
+    |      'rate': array-like of size (N, M) with continuum power rate in W.m^3.
+
+    :param repository_path: Path to the atomic data repository.
     """
 
     update_line_power_rates({
@@ -89,13 +114,22 @@ def add_continuum_power_rate(species, charge, rate, repository_path=None):
 
 def update_continuum_power_rates(rates, repository_path=None):
     """
-    Update the repository of ContinuumPower rates.
-
-    ContinuumPower rate file structure
-
+    Update the files for the continuum power rates:
     /radiated_power/continuum/<species>.json
+    in the atomic data repository.
 
     File contains multiple rates, indexed by ion's charge state.
+
+    :param rates: Dictionary in the form {<species>: {<charge>: <rate>}}, where
+
+    |      <species> is the plasma species (Element/Isotope),
+    |      <charge> is the charge of the plasma species,
+    |      <rate> is the continuum power rate dictionary containing the following entries:
+    |          'ne': array-like of size (N) with electron density in m^-3,
+    |          'te': array-like of size (M) with electron temperature in eV,
+    |          'rate': array-like of size (N, M) with continuum power rate in W.m^3.
+
+    :param repository_path: Path to the atomic data repository.
     """
 
     repository_path = repository_path or DEFAULT_REPOSITORY_PATH
@@ -113,13 +147,22 @@ def update_continuum_power_rates(rates, repository_path=None):
 
 def add_cx_power_rate(species, charge, rate, repository_path=None):
     """
-    Adds a single CXRadiationPower rate to the repository.
+    Adds a single CX radiation power rate to the repository
+    (charge exchage with neutral hydrogen).
 
     If adding multiple rates, consider using the update_cx_power_rates()
     function instead. The update function avoids repeatedly opening and closing
     the rate files.
 
-    :param repository_path:
+    :param species: Plasma species (Element/Isotope).
+    :param charge: Charge of the plasma species.
+    :param rate: CX power rate dictionary containing the following entries:
+
+    |      'ne': array-like of size (N) with electron density in m^-3,
+    |      'te': array-like of size (M) with electron temperature in eV,
+    |      'rate': array-like of size (N, M) with CX power rate in W.m^3.
+
+    :param repository_path: Path to the atomic data repository.
     """
 
     update_line_power_rates({
@@ -131,13 +174,23 @@ def add_cx_power_rate(species, charge, rate, repository_path=None):
 
 def update_cx_power_rates(rates, repository_path=None):
     """
-    Update the repository of CXRadiationPower rates.
-
-    CXRadiationPower rate file structure
-
+    Update the files for the CX radiation power rates
+    (charge exchage with neutral hydrogen):
     /radiated_power/cx/<species>.json
+    in the atomic data repository.
 
     File contains multiple rates, indexed by ion's charge state.
+
+    :param rates: Dictionary in the form {<species>: {<charge>: <rate>}}, where
+
+    |      <species> is the plasma species (Element/Isotope),
+    |      <charge> is the charge of the plasma species,
+    |      <rate> is the thermal CX power rate dictionary containing the following entries:
+    |          'ne': array-like of size (N) with electron density in m^-3,
+    |          'te': array-like of size (M) with electron temperature in eV,
+    |          'rate': array-like of size (N, M) with thermal CX power rate in W.m^3.
+
+    :param repository_path: Path to the atomic data repository.    
     """
 
     repository_path = repository_path or DEFAULT_REPOSITORY_PATH
@@ -199,6 +252,21 @@ def _update_and_write_adf11(species, rate_data, path):
 
 
 def get_line_radiated_power_rate(element, charge, repository_path=None):
+    """
+    Reads the line radiated power rate for the given species and charge
+    from the atomic data repository.
+
+    :param element: Plasma species (Element/Isotope).
+    :param charge: Charge of the plasma species.
+    :param repository_path: Path to the atomic data repository.
+
+    :return rate: Line radiated power rate dictionary containing the following entries:
+
+    |      'ne': 1D array of size (N) with electron density in m^-3,
+    |      'te': 1D array of size (M) with electron temperature in eV,
+    |      'rate': 2D array of size (N, M) with line radiated power rate in W.m^3.
+
+    """
 
     repository_path = repository_path or DEFAULT_REPOSITORY_PATH
 
@@ -220,6 +288,21 @@ def get_line_radiated_power_rate(element, charge, repository_path=None):
 
 
 def get_continuum_radiated_power_rate(element, charge, repository_path=None):
+    """
+    Reads the continuum power rate for the given species and charge
+    from the atomic data repository.
+
+    :param element: Plasma species (Element/Isotope).
+    :param charge: Charge of the plasma species.
+    :param repository_path: Path to the atomic data repository.
+
+    :return rate: Continuum power rate dictionary containing the following entries:
+
+    |      'ne': 1D array of size (N) with electron density in m^-3,
+    |      'te': 1D array of size (M) with electron temperature in eV,
+    |      'rate': 2D array of size (N, M) with continuum power rate in W.m^3.
+
+    """
 
     repository_path = repository_path or DEFAULT_REPOSITORY_PATH
 
@@ -241,6 +324,21 @@ def get_continuum_radiated_power_rate(element, charge, repository_path=None):
 
 
 def get_cx_radiated_power_rate(element, charge, repository_path=None):
+    """
+    Reads the CX radiation power rate for the given species and charge
+    from the atomic data repository.
+
+    :param element: Plasma species (Element/Isotope).
+    :param charge: Charge of the plasma species.
+    :param repository_path: Path to the atomic data repository.
+
+    :return rate: CX radiation power rate dictionary containing the following entries:
+
+    |      'ne': 1D array of size (N) with electron density in m^-3,
+    |      'te': 1D array of size (M) with electron temperature in eV,
+    |      'rate': 2D array of size (N, M) with CX radiation power rate in W.m^3.
+
+    """
 
     repository_path = repository_path or DEFAULT_REPOSITORY_PATH
 

--- a/cherab/openadas/repository/wavelength.py
+++ b/cherab/openadas/repository/wavelength.py
@@ -1,6 +1,6 @@
-# Copyright 2016-2018 Euratom
-# Copyright 2016-2018 United Kingdom Atomic Energy Authority
-# Copyright 2016-2018 Centro de Investigaciones Energéticas, Medioambientales y Tecnológicas
+# Copyright 2016-2024 Euratom
+# Copyright 2016-2024 United Kingdom Atomic Energy Authority
+# Copyright 2016-2024 Centro de Investigaciones Energéticas, Medioambientales y Tecnológicas
 #
 # Licensed under the EUPL, Version 1.1 or – as soon they will be approved by the
 # European Commission - subsequent versions of the EUPL (the "Licence");
@@ -35,11 +35,11 @@ def add_wavelength(element, charge, transition, wavelength, repository_path=None
     function instead. The update function avoid repeatedly opening and closing
     the rate files.
 
-    :param element:
-    :param charge:
-    :param transition:
-    :param wavelength:
-    :param repository_path:
+    :param element: Plasma species (Element/Isotope).
+    :param charge: Charge of the plasma species.
+    :param transition: Tuple containing (initial level, final level).
+    :param wavelength: Transition's wavelength in nm.
+    :param repository_path: Path to the atomic data repository.
     """
 
     update_wavelengths({
@@ -52,6 +52,22 @@ def add_wavelength(element, charge, transition, wavelength, repository_path=None
 
 
 def update_wavelengths(wavelengths, repository_path=None):
+    """
+    Updates the wavelength files `/wavelength/<species>/<charge>.json`
+    in atomic data repository.
+
+    File contains multiple rates, indexed by the transitions.
+
+    :param wavelengths: Dictionary in the form:
+
+    |  { <species>: { <charge>: { <transition>: <wavelength> } } }, where
+    |      <species> is the plasma species (Element/Isotope),
+    |      <charge> is the charge of the plasma species,
+    |      <transition> is the tuple containing (initial level, final level),
+    |      <wavelength> is the transition's wavelength in nm.
+
+    :param repository_path: Path to the atomic data repository.
+    """
 
     repository_path = repository_path or DEFAULT_REPOSITORY_PATH
 
@@ -90,6 +106,16 @@ def update_wavelengths(wavelengths, repository_path=None):
 
 
 def get_wavelength(element, charge, transition, repository_path=None):
+    """
+    Reads the wavelength for the given species, charge and transition from the repository.
+
+    :param element: Plasma species (Element/Isotope).
+    :param charge: Charge of the plasma species.
+    :param transition: Tuple containing (initial level, final level).
+    :param repository_path: Path to the atomic data repository.
+
+    :return wavelength: Wavelength in nm.
+    """
 
     repository_path = repository_path or DEFAULT_REPOSITORY_PATH
     path = os.path.join(repository_path, 'wavelength/{}/{}.json'.format(element.symbol.lower(), charge))

--- a/docs/source/atomic/atomic_data.rst
+++ b/docs/source/atomic/atomic_data.rst
@@ -7,3 +7,5 @@ Atomic Data
    emission_lines
    rate_coefficients
    gaunt_factors
+   repository
+   openadas

--- a/docs/source/atomic/openadas.rst
+++ b/docs/source/atomic/openadas.rst
@@ -1,0 +1,29 @@
+Open-ADAS
+---------
+
+Although a typical Open-ADAS data set is installed to the local atomic data repository
+using the `populate()` function, additional atomic data can be installed manually.
+
+The following functions allow to parse the Open-ADAS files and install the rates of the atomic processes
+to the local atomic data repository.
+
+Parse
+^^^^^
+
+.. autofunction:: cherab.openadas.parse.adf11.parse_adf11
+
+.. autofunction:: cherab.openadas.parse.adf12.parse_adf12
+
+.. autofunction:: cherab.openadas.parse.adf15.parse_adf15
+
+.. autofunction:: cherab.openadas.parse.adf21.parse_adf21
+
+.. autofunction:: cherab.openadas.parse.adf22.parse_adf22bmp
+
+.. autofunction:: cherab.openadas.parse.adf22.parse_adf22bme
+
+Install
+^^^^^^^
+
+.. automodule:: cherab.openadas.install
+    :members:

--- a/docs/source/atomic/repository.rst
+++ b/docs/source/atomic/repository.rst
@@ -1,0 +1,83 @@
+
+Atomic data repository
+----------------------
+
+The following functions allow to manipulate the local atomic data repository:
+add the rates of the atomic processes, update existing ones or get the data
+already present in the repository.
+
+The default repository is created at `~/.cherab/openadas/repository`.
+Cherab supports multiple atomic data repositories. The user can configure different
+repositories by setting the `repository_path` parameter.
+The data in these repositories can be accessed through the `OpenADAS` atomic data provider
+by specifying the `data_path` parameter.
+
+To create the new atomic data repository at the default location and populate it with a typical
+set of rates and wavelengths from Open-ADAS, do:
+
+.. code-block:: pycon
+
+   >>> from cherab.openadas.repository import populate
+   >>> populate()
+
+.. autofunction:: cherab.openadas.repository.create.populate
+
+Wavelength
+^^^^^^^^^^
+
+.. automodule:: cherab.openadas.repository.wavelength
+    :members:
+
+Ionisation
+^^^^^^^^^^
+
+.. autofunction:: cherab.openadas.repository.atomic.add_ionisation_rate
+
+.. autofunction:: cherab.openadas.repository.atomic.get_ionisation_rate
+
+.. autofunction:: cherab.openadas.repository.atomic.update_ionisation_rates
+
+Recombination
+^^^^^^^^^^^^^
+
+.. autofunction:: cherab.openadas.repository.atomic.add_recombination_rate
+
+.. autofunction:: cherab.openadas.repository.atomic.get_recombination_rate
+
+.. autofunction:: cherab.openadas.repository.atomic.update_recombination_rates
+
+Thermal Charge Exchange
+^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autofunction:: cherab.openadas.repository.atomic.add_thermal_cx_rate
+
+.. autofunction:: cherab.openadas.repository.atomic.get_thermal_cx_rate
+
+.. autofunction:: cherab.openadas.repository.atomic.update_thermal_cx_rates
+
+Photon Emissivity Coefficients
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. automodule:: cherab.openadas.repository.pec
+    :members:
+
+Radiated Power
+^^^^^^^^^^^^^^
+
+.. automodule:: cherab.openadas.repository.radiated_power
+    :members:
+
+Beam
+^^^^
+
+.. automodule:: cherab.openadas.repository.beam.cx
+    :members:
+
+.. automodule:: cherab.openadas.repository.beam.emission
+    :members:
+
+.. automodule:: cherab.openadas.repository.beam.population
+    :members:
+
+.. automodule:: cherab.openadas.repository.beam.stopping
+    :members:


### PR DESCRIPTION
This PR improves documentation for the `openadas.repository` get/add/update functions as well as for the `openadas.install` functions and adds corresponding documentation pages.

This is a second PR in a series intended to replace the bloated PR https://github.com/cherab/core/pull/377.