### PR TITLE
Improve and expand the documentation for the atomic data interpolators

### DIFF
--- a/cherab/openadas/rates/atomic.pyx
+++ b/cherab/openadas/rates/atomic.pyx
@@ -1,7 +1,7 @@
 
-# Copyright 2016-2021 Euratom
-# Copyright 2016-2021 United Kingdom Atomic Energy Authority
-# Copyright 2016-2021 Centro de Investigaciones Energéticas, Medioambientales y Tecnológicas
+# Copyright 2016-2024 Euratom
+# Copyright 2016-2024 United Kingdom Atomic Energy Authority
+# Copyright 2016-2024 Centro de Investigaciones Energéticas, Medioambientales y Tecnológicas
 #
 # Licensed under the EUPL, Version 1.1 or – as soon they will be approved by the
 # European Commission - subsequent versions of the EUPL (the "Licence");
@@ -24,12 +24,26 @@ from raysect.core.math.function.float cimport Interpolator2DArray
 
 
 cdef class IonisationRate(CoreIonisationRate):
+    """
+    Ionisation rate.
+
+    Data is interpolated with cubic spline in log-log space.
+    Nearest neighbour extrapolation is used if extrapolate is True.
+
+    :param dict data: Ionisation rate dictionary containing the following entries:
+
+    |   'ne': 1D array of size (N) with electron density in m^-3,
+    |   'te': 1D array of size (M) with electron temperature in eV,
+    |   'rate': 2D array of size (N, M) with ionisation rate in m^3.s^-1.
+
+    :param bint extrapolate: Enable extrapolation (default=False).
+
+    :ivar tuple density_range: Electron density interpolation range.
+    :ivar tuple temperature_range: Electron temperature interpolation range.
+    :ivar dict raw_data: Dictionary containing the raw data.
+    """
 
     def __init__(self, dict data, extrapolate=False):
-        """
-        :param data: Dictionary containing rate data.
-        :param extrapolate: Enable extrapolation (default=False).
-        """
 
         self.raw_data = data
 
@@ -62,7 +76,7 @@ cdef class IonisationRate(CoreIonisationRate):
 
 cdef class NullIonisationRate(CoreIonisationRate):
     """
-    A PEC rate that always returns zero.
+    An ionisation rate that always returns zero.
     Needed for use cases where the required atomic data is missing.
     """
 
@@ -71,12 +85,26 @@ cdef class NullIonisationRate(CoreIonisationRate):
 
 
 cdef class RecombinationRate(CoreRecombinationRate):
+    """
+    Recombination rate.
+
+    Data is interpolated with cubic spline in log-log space.
+    Nearest neighbour extrapolation is used if extrapolate is True.
+
+    :param dict data: Recombination rate dictionary containing the following entries:
+
+    |       'ne': 1D array of size (N) with electron density in m^-3,
+    |       'te': 1D array of size (M) with electron temperature in eV,
+    |       'rate': 2D array of size (N, M) with recombination rate in m^3.s^-1.
+
+    :param bint extrapolate: Enable extrapolation (default=False).
+
+    :ivar tuple density_range: Electron density interpolation range.
+    :ivar tuple temperature_range: Electron temperature interpolation range.
+    :ivar dict raw_data: Dictionary containing the raw data.
+    """
 
     def __init__(self, dict data, extrapolate=False):
-        """
-        :param data: Dictionary containing rate data.
-        :param extrapolate: Enable extrapolation (default=False).
-        """
 
         self.raw_data = data
 
@@ -109,7 +137,7 @@ cdef class RecombinationRate(CoreRecombinationRate):
 
 cdef class NullRecombinationRate(CoreRecombinationRate):
     """
-    A PEC rate that always returns zero.
+    A recombination rate that always returns zero.
     Needed for use cases where the required atomic data is missing.
     """
 
@@ -118,12 +146,26 @@ cdef class NullRecombinationRate(CoreRecombinationRate):
 
 
 cdef class ThermalCXRate(CoreThermalCXRate):
+    """
+    Thermal charge exchange rate.
+
+    Data is interpolated with cubic spline in log-log space.
+    Linear extrapolation is used if extrapolate is True.
+
+    :param dict data: CX rate dictionary containing the following entries:
+
+    |       'ne': 1D array of size (N) with electron density in m^-3,
+    |       'te': 1D array of size (M) with electron temperature in eV,
+    |       'rate': 2D array of size (N, M) with thermal CX rate in m^3.s^-1.
+
+    :param bint extrapolate: Enable extrapolation (default=False).
+
+    :ivar tuple density_range: Electron density interpolation range.
+    :ivar tuple temperature_range: Electron temperature interpolation range.
+    :ivar dict raw_data: Dictionary containing the raw data.
+    """
 
     def __init__(self, dict data, extrapolate=False):
-        """
-        :param data: Dictionary containing rate data.
-        :param extrapolate: Enable extrapolation (default=False).
-        """
 
         self.raw_data = data
 
@@ -155,7 +197,7 @@ cdef class ThermalCXRate(CoreThermalCXRate):
 
 cdef class NullThermalCXRate(CoreThermalCXRate):
     """
-    A PEC rate that always returns zero.
+    A thermal CX rate that always returns zero.
     Needed for use cases where the required atomic data is missing.
     """
 

--- a/cherab/openadas/rates/beam.pyx
+++ b/cherab/openadas/rates/beam.pyx
@@ -1,6 +1,6 @@
-# Copyright 2016-2021 Euratom
-# Copyright 2016-2021 United Kingdom Atomic Energy Authority
-# Copyright 2016-2021 Centro de Investigaciones Energéticas, Medioambientales y Tecnológicas
+# Copyright 2016-2024 Euratom
+# Copyright 2016-2024 United Kingdom Atomic Energy Authority
+# Copyright 2016-2024 Centro de Investigaciones Energéticas, Medioambientales y Tecnológicas
 #
 # Licensed under the EUPL, Version 1.1 or – as soon they will be approved by the
 # European Commission - subsequent versions of the EUPL (the "Licence");
@@ -31,8 +31,26 @@ cdef class BeamStoppingRate(CoreBeamStoppingRate):
     """
     The beam stopping coefficient interpolation class.
 
-    :param data: A dictionary holding the beam coefficient data.
-    :param extrapolate: Set to True to enable extrapolation, False to disable (default).
+    Data is interpolated with cubic spline in log-log space.
+    Linear and quadratic extrapolations are used for "sen" and "st" respectively
+    if extrapolate is True.
+
+    :param dict data: A beam stopping rate dictionary containing the following entries:
+
+    |      'e': 1D array of size (N) with interaction energy in eV/amu,
+    |      'n': 1D array of size (M) with target electron density in m^-3,
+    |      't': 1D array of size (K) with target electron temperature in eV,
+    |      'sen': 2D array of size (N, M) with beam stopping rate energy component in m^3.s^-1.
+    |      'st': 1D array of size (K) with beam stopping rate temperature component in m^3.s^-1.
+    |      'sref': reference beam stopping rate in m^3.s^-1.
+    |  The total beam stopping rate: s = sen * st / sref.
+
+    :param bint extrapolate: Set to True to enable extrapolation, False to disable (default).
+
+    :ivar tuple beam_energy_range: Interaction energy interpolation range.
+    :ivar tuple density_range: Target electron density interpolation range.
+    :ivar tuple temperature_range: Target electron temperature interpolation range.
+    :ivar dict raw_data: Dictionary containing the raw data.
     """
 
     @cython.cdivision(True)
@@ -93,7 +111,7 @@ cdef class BeamStoppingRate(CoreBeamStoppingRate):
 
 cdef class NullBeamStoppingRate(CoreBeamStoppingRate):
     """
-    A beam rate that always returns zero.
+    A beam stopping rate that always returns zero.
     Needed for use cases where the required atomic data is missing.
     """
 
@@ -105,8 +123,26 @@ cdef class BeamPopulationRate(CoreBeamPopulationRate):
     """
     The beam population coefficient interpolation class.
 
-    :param data: A dictionary holding the beam coefficient data.
-    :param extrapolate: Set to True to enable extrapolation, False to disable (default).
+    Data is interpolated with cubic spline in log-log space.
+    Linear and quadratic extrapolations are used for "sen" and "st" respectively
+    if extrapolate is True.
+
+    :param dict data: Beam population rate dictionary containing the following entries:
+
+    |      'e': 1D array of size (N) with interaction energy in eV/amu,
+    |      'n': 1D array of size (M) with target electron density in m^-3,
+    |      't': 1D array of size (K) with target electron temperature in eV,
+    |      'sen': 2D array of size (N, M) with dimensionless beam population rate energy component.
+    |      'st': 1D array of size (K) with dimensionless beam population rate temperature component.
+    |      'sref': reference dimensionless beam population rate.
+    |  The total beam population rate: s = sen * st / sref.
+
+    :param bint extrapolate: Set to True to enable extrapolation, False to disable (default).
+
+    :ivar tuple beam_energy_range: Interaction energy interpolation range.
+    :ivar tuple density_range: Target electron density interpolation range.
+    :ivar tuple temperature_range: Target electron temperature interpolation range.
+    :ivar dict raw_data: Dictionary containing the raw data.
     """
 
     @cython.cdivision(True)
@@ -167,7 +203,7 @@ cdef class BeamPopulationRate(CoreBeamPopulationRate):
 
 cdef class NullBeamPopulationRate(CoreBeamPopulationRate):
     """
-    A beam rate that always returns zero.
+    A beam population rate that always returns zero.
     Needed for use cases where the required atomic data is missing.
     """
 
@@ -179,9 +215,26 @@ cdef class BeamEmissionPEC(CoreBeamEmissionPEC):
     """
     The beam emission coefficient interpolation class.
 
-    :param data: A dictionary holding the beam coefficient data.
-    :param wavelength: The natural wavelength of the emission line associated with the rate data in nm.
-    :param extrapolate: Set to True to enable extrapolation, False to disable (default).
+    Data is interpolated with cubic spline in log-log space.
+    Linear and quadratic extrapolations are used for "sen" and "st" respectively
+    if extrapolate is True.
+
+    :param dict data: Beam emission rate dictionary containing the following entries:
+
+    |      'e': 1D array of size (N) with interaction energy in eV/amu,
+    |      'n' 1D array of size (M) with target electron density in m^-3,
+    |      't' 1D array of size (K) with target electron temperature in eV,
+    |      'sen' 2D array of size (N, M) with beam emission rate energy component in photon.m^3.s^-1.
+    |      'st' 1D array of size (K) with beam emission rate temperature component in photon.m^3.s^-1.
+    |      'sref': reference beam emission rate in photon.m^3.s^-1.
+
+    :param double wavelength: The natural wavelength of the emission line associated with the rate data in nm.
+    :param bint extrapolate: Set to True to enable extrapolation, False to disable (default).
+
+    :ivar tuple beam_energy_range: Interaction energy interpolation range.
+    :ivar tuple density_range: Target electron density interpolation range.
+    :ivar tuple temperature_range: Target electron temperature interpolation range.
+    :ivar dict raw_data: Dictionary containing the raw data.
     """
 
     @cython.cdivision(True)
@@ -194,7 +247,7 @@ cdef class BeamEmissionPEC(CoreBeamEmissionPEC):
         e = data["e"]                                   # eV/amu
         n = data["n"]                                   # m^-3
         t = data["t"]                                   # eV
-        sen = np.log10(PhotonToJ.to(data["sen"], wavelength))     # W.m^3/s
+        sen = np.log10(PhotonToJ.to(data["sen"], wavelength))     # W.m^3
         st = np.log10(data["st"] / data["sref"])                  # dimensionless
 
         # store limits of data
@@ -243,7 +296,7 @@ cdef class BeamEmissionPEC(CoreBeamEmissionPEC):
 
 cdef class NullBeamEmissionPEC(CoreBeamEmissionPEC):
     """
-    A beam rate that always returns zero.
+    A beam emission PEC that always returns zero.
     Needed for use cases where the required atomic data is missing.
     """
 

--- a/cherab/openadas/rates/cx.pyx
+++ b/cherab/openadas/rates/cx.pyx
@@ -1,6 +1,6 @@
-# Copyright 2016-2021 Euratom
-# Copyright 2016-2021 United Kingdom Atomic Energy Authority
-# Copyright 2016-2021 Centro de Investigaciones Energéticas, Medioambientales y Tecnológicas
+# Copyright 2016-2024 Euratom
+# Copyright 2016-2024 United Kingdom Atomic Energy Authority
+# Copyright 2016-2024 Centro de Investigaciones Energéticas, Medioambientales y Tecnológicas
 #
 # Licensed under the EUPL, Version 1.1 or – as soon they will be approved by the
 # European Commission - subsequent versions of the EUPL (the "Licence");
@@ -26,12 +26,42 @@ from raysect.core.math.function.float cimport Interpolator1DArray, Constant1D
 
 cdef class BeamCXPEC(CoreBeamCXPEC):
     """
-    The effective cx rate interpolation class.
+    Effective charge exchange photon emission coefficient.
 
-    :param donor_metastable: The metastable state of the donor species for which the rate data applies.
-    :param wavelength: The natural wavelength of the emission line associated with the rate data in nm.
-    :param data: A dictionary holding the rate data.
-    :param extrapolate: Set to True to enable extrapolation, False to disable (default).
+    The data for "qeb" is interpolated with a cubic spline in log-log space.
+    The data for "qti", "qni", "qz" and "qb" are interpolated with a cubic spline
+    in linear space.
+
+    Quadratic extrapolation is used for "qeb" and nearest neighbour extrapolation is used for
+    "qti", "qni", "qz" and "qb" if extrapolate is True.
+
+    :param int donor_metastable: The metastable state of the donor species for which the rate data applies.
+    :param double wavelength: The natural wavelength of the emission line associated with the rate data in nm.
+    :param data: Beam CX PEC dictionary containing the following entries:
+
+    |      'eb': 1D array of size (N) with beam energy in eV/amu,
+    |      'ti': 1D array of size (M) with receiver ion temperature in eV,
+    |      'ni': 1D array of size (K) with receiver ion density in m^-3,
+    |      'z': 1D array of size (L) with receiver Z-effective,
+    |      'b': 1D array of size (J) with magnetic field strength in Tesla,
+    |      'qeb': 1D array of size (N) with CX PEC energy component in photon.m^3.s-1,
+    |      'qti': 1D array of size (M) with CX PEC temperature component in photon.m^3.s-1,
+    |      'qni': 1D array of size (K) with CX PEC density component in photon.m^3.s-1,
+    |      'qz': 1D array of size (L) with CX PEC Zeff component in photon.m^3.s-1,
+    |      'qb': 1D array of size (J) with CX PEC B-field component in photon.m^3.s-1,
+    |      'qref': reference CX PEC in photon.m^3.s-1.
+    |  The total beam CX PEC: q = qeb * qti * qni * qz * qb / qref^4.
+
+    :param bint extrapolate: Set to True to enable extrapolation, False to disable (default).
+
+    :ivar tuple beam_energy_range: Interaction energy interpolation range.
+    :ivar tuple density_range: Receiver ion density interpolation range.
+    :ivar tuple temperature_range: Receiver ion temperature interpolation range.
+    :ivar tuple zeff_range: Z-effective interpolation range.
+    :ivar tuple b_field_range: Magnetic field strength interpolation range.
+    :ivar int donor_metastable: The metastable state of the donor species.
+    :ivar double wavelength: The natural wavelength of the emission line in nm.
+    :ivar dict raw_data: Dictionary containing the raw data.
     """
 
     @cython.cdivision(True)
@@ -79,7 +109,7 @@ cdef class BeamCXPEC(CoreBeamCXPEC):
 
         :param energy: Interaction energy in eV/amu.
         :param temperature: Receiver ion temperature in eV.
-        :param density: Receiver ion density in m^-3
+        :param density: Plasma total ion density in m^-3
         :param z_effective: Plasma Z-effective.
         :param b_field: Magnetic field magnitude in Tesla.
         :return: The effective cx rate in W.m^3

--- a/cherab/openadas/rates/pec.pyx
+++ b/cherab/openadas/rates/pec.pyx
@@ -1,6 +1,6 @@
-# Copyright 2016-2021 Euratom
-# Copyright 2016-2021 United Kingdom Atomic Energy Authority
-# Copyright 2016-2021 Centro de Investigaciones Energéticas, Medioambientales y Tecnológicas
+# Copyright 2016-2024 Euratom
+# Copyright 2016-2024 United Kingdom Atomic Energy Authority
+# Copyright 2016-2024 Centro de Investigaciones Energéticas, Medioambientales y Tecnológicas
 #
 # Licensed under the EUPL, Version 1.1 or – as soon they will be approved by the
 # European Commission - subsequent versions of the EUPL (the "Licence");
@@ -25,13 +25,27 @@ from cherab.core.utility.conversion import PhotonToJ
 
 
 cdef class ImpactExcitationPEC(CoreImpactExcitationPEC):
+    """
+    Electron impact excitation photon emission coefficient.
+
+    The data is interpolated with cubic spline in log-log space.
+    Nearest neighbour extrapolation is used if extrapolate is True.
+
+    :param double wavelength: Resting wavelength of corresponding emission line in nm.
+    :param dict data: Excitation PEC dictionary containing the following entries:
+
+    |      'ne': 1D array of size (N) with electron density in m^-3,
+    |      'te': 1D array of size (M) with electron temperature in eV,
+    |      'rate': 2D array of size (N, M) with excitation PEC in photon.m^3.s^-1.
+
+    :param bint extrapolate: Enable extrapolation (default=False).
+
+    :ivar tuple density_range: Electron density interpolation range.
+    :ivar tuple temperature_range: Electron temperature interpolation range.
+    :ivar dict raw_data: Dictionary containing the raw data.
+    """
 
     def __init__(self, double wavelength, dict data, extrapolate=False):
-        """
-        :param wavelength: Resting wavelength of corresponding emission line in nm.
-        :param data: Dictionary containing rate data.
-        :param extrapolate: Enable extrapolation (default=False).
-        """
 
         self.wavelength = wavelength
         self.raw_data = data
@@ -68,7 +82,7 @@ cdef class ImpactExcitationPEC(CoreImpactExcitationPEC):
 
 cdef class NullImpactExcitationPEC(CoreImpactExcitationPEC):
     """
-    A PEC rate that always returns zero.
+    A electron impact excitation PEC rate that always returns zero.
     Needed for use cases where the required atomic data is missing.
     """
 
@@ -77,13 +91,27 @@ cdef class NullImpactExcitationPEC(CoreImpactExcitationPEC):
 
 
 cdef class RecombinationPEC(CoreRecombinationPEC):
+    """
+    Recombination photon emission coefficient.
+
+    The data is interpolated with cubic spline in log-log space.
+    Nearest neighbour extrapolation is used if extrapolate is True.
+
+    :param double wavelength: Resting wavelength of corresponding emission line in nm.
+    :param dict data: Rcombination PEC dictionary containing the following entries:
+
+    |      'ne': 1D array of size (N) with electron density in m^-3,
+    |      'te': 1D array of size (M) with electron temperature in eV,
+    |      'rate': 2D array of size (N, M) with recombination PEC in photon.m^3.s^-1.
+
+    :param bint extrapolate: Enable extrapolation (default=False).
+
+    :ivar tuple density_range: Electron density interpolation range.
+    :ivar tuple temperature_range: Electron temperature interpolation range.
+    :ivar dict raw_data: Dictionary containing the raw data.
+    """
 
     def __init__(self, double wavelength, dict data, extrapolate=False):
-        """
-        :param wavelength: Resting wavelength of corresponding emission line in nm.
-        :param data: Dictionary containing rate data.
-        :param extrapolate: Enable extrapolation (default=False).
-        """
 
         self.wavelength = wavelength
         self.raw_data = data
@@ -120,7 +148,7 @@ cdef class RecombinationPEC(CoreRecombinationPEC):
 
 cdef class NullRecombinationPEC(CoreRecombinationPEC):
     """
-    A PEC rate that always returns zero.
+    A recombination PEC rate that always returns zero.
     Needed for use cases where the required atomic data is missing.
     """
 

--- a/cherab/openadas/rates/radiated_power.pyx
+++ b/cherab/openadas/rates/radiated_power.pyx
@@ -1,7 +1,7 @@
 
-# Copyright 2016-2021 Euratom
-# Copyright 2016-2021 United Kingdom Atomic Energy Authority
-# Copyright 2016-2021 Centro de Investigaciones Energéticas, Medioambientales y Tecnológicas
+# Copyright 2016-2024 Euratom
+# Copyright 2016-2024 United Kingdom Atomic Energy Authority
+# Copyright 2016-2024 Centro de Investigaciones Energéticas, Medioambientales y Tecnológicas
 #
 # Licensed under the EUPL, Version 1.1 or – as soon they will be approved by the
 # European Commission - subsequent versions of the EUPL (the "Licence");
@@ -24,7 +24,26 @@ from raysect.core.math.function.float cimport Interpolator2DArray
 
 
 cdef class LineRadiationPower(CoreLineRadiationPower):
-    """Base class for radiated powers."""
+    """
+    Line radiated power coefficient.
+
+    The data is interpolated with cubic spline in log-log space.
+    Nearest neighbour extrapolation is used if extrapolate is True.
+
+    :param Element species: Element object defining the ion type.
+    :param int ionisation: Charge state of the ion.
+    :param dict data: Line radiated power rate dictionary containing the following entries:
+
+    |      'ne': 1D array of size (N) with electron density in m^-3,
+    |      'te': 1D array of size (M) with electron temperature in eV,
+    |      'rate': 2D array of size (N, M) with radiated power rate in W.m^3.
+
+    :param bint extrapolate: Enable extrapolation (default=False).
+
+    :ivar tuple density_range: Electron density interpolation range.
+    :ivar tuple temperature_range: Electron temperature interpolation range.
+    :ivar dict raw_data: Dictionary containing the raw data.
+    """
 
     def __init__(self, species, ionisation, dict data, extrapolate=False):
 
@@ -70,7 +89,26 @@ cdef class NullLineRadiationPower(CoreLineRadiationPower):
 
 
 cdef class ContinuumPower(CoreContinuumPower):
-    """Base class for radiated powers."""
+    """
+    Recombination continuum radiated power coefficient.
+
+    The data is interpolated with cubic spline in log-log space.
+    Nearest neighbour extrapolation is used if extrapolate is True.
+
+    :param Element species: Element object defining the ion type.
+    :param int ionisation: Charge state of the ion.
+    :param dict data: Recombination continuum radiated power rate dictionary containing the following entries:
+
+    |      'ne': 1D array of size (N) with electron density in m^-3,
+    |      'te': 1D array of size (M) with electron temperature in eV,
+    |      'rate': 2D array of size (N, M) with radiated power rate in W.m^3.
+
+    :param bint extrapolate: Enable extrapolation (default=False).
+
+    :ivar tuple density_range: Electron density interpolation range.
+    :ivar tuple temperature_range: Electron temperature interpolation range.
+    :ivar dict raw_data: Dictionary containing the raw data.
+    """
 
     def __init__(self, species, ionisation, dict data, extrapolate=False):
 
@@ -116,7 +154,26 @@ cdef class NullContinuumPower(CoreContinuumPower):
 
 
 cdef class CXRadiationPower(CoreCXRadiationPower):
-    """Base class for radiated powers."""
+    """
+    Charge exchange radiated power coefficient.
+
+    The data is interpolated with cubic spline in log-log space.
+    Linear extrapolation is used if extrapolate is True.
+
+    :param Element species: Element object defining the ion type.
+    :param int ionisation: Charge state of the ion.
+    :param dict data: CX radiated power rate dictionary containing the following entries:
+
+    |      'ne': 1D array of size (N) with electron density in m^-3,
+    |      'te': 1D array of size (M) with electron temperature in eV,
+    |      'rate': 2D array of size (N, M) with radiated power rate in W.m^3.
+
+    :param bint extrapolate: Enable extrapolation (default=False).
+
+    :ivar tuple density_range: Electron density interpolation range.
+    :ivar tuple temperature_range: Electron temperature interpolation range.
+    :ivar dict raw_data: Dictionary containing the raw data.
+    """
 
     def __init__(self, species, ionisation, dict data, extrapolate=False):
 

--- a/docs/source/atomic/atomic_data.rst
+++ b/docs/source/atomic/atomic_data.rst
@@ -7,3 +7,4 @@ Atomic Data
    emission_lines
    rate_coefficients
    gaunt_factors
+   data_interpolators

--- a/docs/source/atomic/data_interpolators.rst
+++ b/docs/source/atomic/data_interpolators.rst
@@ -1,0 +1,89 @@
+Atomic data interpolators
+=========================
+
+The following classes interpolate atomic data defined on a numerical grid.
+
+
+Atomic Processes
+^^^^^^^^^^^^^^^^
+
+.. autoclass:: cherab.openadas.rates.atomic.IonisationRate
+   :members:
+
+.. autoclass:: cherab.openadas.rates.atomic.NullIonisationRate
+   :members:
+
+.. autoclass:: cherab.openadas.rates.atomic.RecombinationRate
+   :members:
+
+.. autoclass:: cherab.openadas.rates.atomic.NullRecombinationRate
+   :members:
+
+.. autoclass:: cherab.openadas.rates.atomic.ThermalCXRate
+   :members:
+
+.. autoclass:: cherab.openadas.rates.atomic.NullThermalCXRate
+   :members:
+
+Photon Emissivity Coefficients
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autoclass:: cherab.openadas.rates.pec.ImpactExcitationPEC
+   :members:
+
+.. autoclass:: cherab.openadas.rates.pec.NullImpactExcitationPEC
+   :members:
+
+.. autoclass:: cherab.openadas.rates.pec.RecombinationPEC
+   :members:
+
+.. autoclass:: cherab.openadas.rates.pec.NullRecombinationPEC
+   :members:
+
+Beam-Plasma Interaction Rates
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autoclass:: cherab.openadas.rates.cx.BeamCXPEC
+   :members:
+
+.. autoclass:: cherab.openadas.rates.cx.NullBeamCXPEC
+   :members:
+
+.. autoclass:: cherab.openadas.rates.beam.BeamStoppingRate
+   :members:
+
+.. autoclass:: cherab.openadas.rates.beam.NullBeamStoppingRate
+   :members:
+
+.. autoclass:: cherab.openadas.rates.beam.BeamPopulationRate
+   :members:
+
+.. autoclass:: cherab.openadas.rates.beam.NullBeamPopulationRate
+   :members:
+
+.. autoclass:: cherab.openadas.rates.beam.BeamEmissionPEC
+   :members:
+
+.. autoclass:: cherab.openadas.rates.beam.NullBeamEmissionPEC
+   :members:
+
+Radiated Power
+^^^^^^^^^^^^^^
+
+.. autoclass:: cherab.openadas.rates.radiated_power.LineRadiationPower
+   :members:
+
+.. autoclass:: cherab.openadas.rates.radiated_power.NullLineRadiationPower
+   :members:
+
+.. autoclass:: cherab.openadas.rates.radiated_power.ContinuumPower
+   :members:
+
+.. autoclass:: cherab.openadas.rates.radiated_power.NullContinuumPower
+   :members:
+
+.. autoclass:: cherab.openadas.rates.radiated_power.CXRadiationPower
+   :members:
+
+.. autoclass:: cherab.openadas.rates.radiated_power.NullCXRadiationPower
+   :members:

--- a/docs/source/atomic/rate_coefficients.rst
+++ b/docs/source/atomic/rate_coefficients.rst
@@ -15,6 +15,35 @@ provide theoretical equations. Cherab emission models only need to know how to c
 them after they have been instantiated.
 
 
+Atomic Processes
+^^^^^^^^^^^^^^^^
+
+.. autoclass:: cherab.core.atomic.rates.IonisationRate
+
+.. autoclass:: cherab.core.atomic.rates.RecombinationRate
+
+.. autoclass:: cherab.core.atomic.rates.ThermalCXRate
+
+The `IonisationRate`, `RecombinationRate` and `ThermalCXRate` classes all share
+the same call signatures.
+
+.. function:: __call__(density, temperature)
+
+   Returns an effective rate coefficient at the specified plasma conditions.
+
+   This function just wraps the cython evaluate() method.
+
+.. function:: evaluate(density, temperature)
+
+   an effective recombination rate coefficient at the specified plasma conditions.
+
+   This function needs to be implemented by the atomic data provider.
+
+   :param float density: Electron density in m^-3
+   :param float temperature: Electron temperature in eV.
+   :return: The effective ionisation rate in [m^3.s^-1].
+
+
 Photon Emissivity Coefficients
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -39,8 +68,8 @@ the same call signatures.
 
    This function needs to be implemented by the atomic data provider.
 
-   :param float temperature: Receiver ion temperature in eV.
    :param float density: Receiver ion density in m^-3
+   :param float temperature: Receiver ion temperature in eV.
    :return: The effective PEC rate [Wm^3].
 
 Some example code for requesting PEC objects and sampling them with the __call__()


### PR DESCRIPTION
This PR improves documentation for the `openadas.rates` atomic data interpolators and creates a documentation page for them. In addition, the missing subsection "Atomic processes" has been added to the "Rate coefficients" section.

This is a third PR in a series intended to replace the bloated PR https://github.com/cherab/core/pull/377.