### PR TITLE
Replace deprecated scipy.integrate.quadrature in the TestLineShapes

### DIFF
--- a/cherab/core/tests/test_lineshapes.py
+++ b/cherab/core/tests/test_lineshapes.py
@@ -20,7 +20,6 @@ import unittest
 
 import numpy as np
 from scipy.special import erf, hyp2f1
-from scipy.integrate import quadrature
 
 from raysect.core import Point3D, Vector3D
 from raysect.core.math.function.float import Arg1D, Constant1D
@@ -372,13 +371,14 @@ class TestLineShapes(unittest.TestCase):
         weight_poly_coeff = [5.14820e-04, 1.38821e+00, -9.60424e-02, -3.83995e-02, -7.40042e-03, -5.47626e-04]
         lorentz_weight = np.exp(np.poly1d(weight_poly_coeff[::-1])(np.log(fwhm_lorentz / fwhm_full)))
 
+        integrator_pi = GaussianQuadrature(stark_lineshape_pi, relative_tolerance=integrator.relative_tolerance)
+        integrator_sigma_plus = GaussianQuadrature(stark_lineshape_sigma_plus, relative_tolerance=integrator.relative_tolerance)
+        integrator_sigma_minus = GaussianQuadrature(stark_lineshape_sigma_minus, relative_tolerance=integrator.relative_tolerance)
+
         for i in range(bins):
-            lorentz_bin = 0.5 * sin_sqr * quadrature(stark_lineshape_pi, wavelengths[i], wavelengths[i + 1],
-                                                     rtol=integrator.relative_tolerance)[0] / delta
-            lorentz_bin += (0.25 * sin_sqr + 0.5 * cos_sqr) * quadrature(stark_lineshape_sigma_plus, wavelengths[i], wavelengths[i + 1],
-                                                                         rtol=integrator.relative_tolerance)[0] / delta
-            lorentz_bin += (0.25 * sin_sqr + 0.5 * cos_sqr) * quadrature(stark_lineshape_sigma_minus, wavelengths[i], wavelengths[i + 1],
-                                                                         rtol=integrator.relative_tolerance)[0] / delta
+            lorentz_bin = 0.5 * sin_sqr * integrator_pi(wavelengths[i], wavelengths[i + 1]) / delta
+            lorentz_bin += (0.25 * sin_sqr + 0.5 * cos_sqr) * integrator_sigma_plus(wavelengths[i], wavelengths[i + 1]) / delta
+            lorentz_bin += (0.25 * sin_sqr + 0.5 * cos_sqr) * integrator_sigma_minus(wavelengths[i], wavelengths[i + 1]) / delta
             ref_value = lorentz_bin * lorentz_weight + gaussian[i] * (1. - lorentz_weight)
             self.assertAlmostEqual(ref_value, spectrum.samples[i], delta=1e-9,
                                    msg='StarkBroadenedLine.add_line() method gives a wrong value at {} nm.'.format(wavelengths[i]))

--- a/cherab/core/tests/test_lineshapes.py
+++ b/cherab/core/tests/test_lineshapes.py
@@ -296,7 +296,8 @@ class TestLineShapes(unittest.TestCase):
         line = Line(deuterium, 0, (6, 2))  # D-delta line
         target_species = self.plasma.composition.get(line.element, line.charge)
         wavelength = 656.104
-        integrator = GaussianQuadrature(relative_tolerance=1.e-8)
+        relative_tolerance = 1.e-8
+        integrator = GaussianQuadrature(relative_tolerance=relative_tolerance)
         stark_line = StarkBroadenedLine(line, wavelength, target_species, self.plasma, self.atomic_data, integrator=integrator)
 
         # spectrum parameters
@@ -373,12 +374,17 @@ class TestLineShapes(unittest.TestCase):
         lorentz_weight = np.exp(np.poly1d(weight_poly_coeff[::-1])(np.log(fwhm_lorentz / fwhm_full)))
 
         for i in range(bins):
-            lorentz_bin = 0.5 * sin_sqr * quad(stark_lineshape_pi, wavelengths[i], wavelengths[i + 1], epsrel=1.e-8)[0]
-            lorentz_bin += (0.25 * sin_sqr + 0.5 * cos_sqr) * quad(stark_lineshape_sigma_plus, wavelengths[i], wavelengths[i + 1], epsrel=1.e-8)[0]
-            lorentz_bin += (0.25 * sin_sqr + 0.5 * cos_sqr) * quad(stark_lineshape_sigma_minus, wavelengths[i], wavelengths[i + 1], epsrel=1.e-8)[0]
+            lorentz_bin = 0.5 * sin_sqr * quad(stark_lineshape_pi, wavelengths[i], wavelengths[i + 1], epsrel=relative_tolerance)[0]
+            lorentz_bin += (0.25 * sin_sqr + 0.5 * cos_sqr) * quad(stark_lineshape_sigma_plus, wavelengths[i], wavelengths[i + 1], epsrel=relative_tolerance)[0]
+            lorentz_bin += (0.25 * sin_sqr + 0.5 * cos_sqr) * quad(stark_lineshape_sigma_minus, wavelengths[i], wavelengths[i + 1], epsrel=relative_tolerance)[0]
             ref_value = lorentz_bin / delta * lorentz_weight + gaussian[i] * (1. - lorentz_weight)
-            self.assertAlmostEqual(ref_value, spectrum.samples[i], delta=1e-8,
-                                   msg='StarkBroadenedLine.add_line() method gives a wrong value at {} nm.'.format(wavelengths[i]))
+            if ref_value:
+                print(ref_value)
+                self.assertAlmostEqual(spectrum.samples[i] / ref_value, 1., delta=relative_tolerance,
+                                       msg='StarkBroadenedLine.add_line() method gives a wrong value at {} nm.'.format(wavelengths[i]))
+            else:
+                self.assertAlmostEqual(ref_value, spectrum.samples[i], delta=relative_tolerance,
+                                       msg='StarkBroadenedLine.add_line() method gives a wrong value at {} nm.'.format(wavelengths[i]))
 
     def test_beam_emission_multiplet(self):
         # Test MSE line shape

--- a/cherab/core/tests/test_lineshapes.py
+++ b/cherab/core/tests/test_lineshapes.py
@@ -374,12 +374,14 @@ class TestLineShapes(unittest.TestCase):
         lorentz_weight = np.exp(np.poly1d(weight_poly_coeff[::-1])(np.log(fwhm_lorentz / fwhm_full)))
 
         for i in range(bins):
-            lorentz_bin = 0.5 * sin_sqr * quad(stark_lineshape_pi, wavelengths[i], wavelengths[i + 1], epsrel=relative_tolerance)[0]
-            lorentz_bin += (0.25 * sin_sqr + 0.5 * cos_sqr) * quad(stark_lineshape_sigma_plus, wavelengths[i], wavelengths[i + 1], epsrel=relative_tolerance)[0]
-            lorentz_bin += (0.25 * sin_sqr + 0.5 * cos_sqr) * quad(stark_lineshape_sigma_minus, wavelengths[i], wavelengths[i + 1], epsrel=relative_tolerance)[0]
+            lorentz_bin = 0.5 * sin_sqr * quad(stark_lineshape_pi, wavelengths[i], wavelengths[i + 1],
+                                               epsrel=relative_tolerance)[0]
+            lorentz_bin += (0.25 * sin_sqr + 0.5 * cos_sqr) * quad(stark_lineshape_sigma_plus, wavelengths[i], wavelengths[i + 1],
+                                                                   epsrel=relative_tolerance)[0]
+            lorentz_bin += (0.25 * sin_sqr + 0.5 * cos_sqr) * quad(stark_lineshape_sigma_minus, wavelengths[i], wavelengths[i + 1],
+                                                                   epsrel=relative_tolerance)[0]
             ref_value = lorentz_bin / delta * lorentz_weight + gaussian[i] * (1. - lorentz_weight)
             if ref_value:
-                print(ref_value)
                 self.assertAlmostEqual(spectrum.samples[i] / ref_value, 1., delta=relative_tolerance,
                                        msg='StarkBroadenedLine.add_line() method gives a wrong value at {} nm.'.format(wavelengths[i]))
             else:


### PR DESCRIPTION
This PR replaces deprecated `scipy.integrate.quadrature` with Cherab's own `GaussianQuadrature` integration method in the `TestLineShapes` test case.