### PR TITLE
Fix uninitialised variable warning in GaussianQuadrature

### DIFF
--- a/cherab/core/math/integrators/integrators1d.pyx
+++ b/cherab/core/math/integrators/integrators1d.pyx
@@ -201,6 +201,7 @@ cdef class GaussianQuadrature(Integrator1D):
             double newval, oldval, error, x, c, d
 
         oldval = INFINITY
+        newval = 0
         ibegin = 0
         c = 0.5 * (a + b)
         d = 0.5 * (b - a)


### PR DESCRIPTION
This PR simply fixes a warning caused by returning a potentially uninitialized variable in `GaussianQuadrature.evaluate()`:
```
cherab/core/math/integrators/integrators1d.c: In function ‘__pyx_f_6cherab_4core_4math_11integrators_13integrators1d_18GaussianQuadrature_evaluate’:
cherab/core/math/integrators/integrators1d.c:31196:10: warning: ‘__pyx_v_newval’ may be used uninitialized in this function [-Wmaybe-uninitialized]
31196 |   return __pyx_r;
```