### PR TITLE
Add r prefix to docstrings with escape characters to fix SyntaxWarnings in Python 3.12

### DIFF
--- a/cherab/core/model/laser/model.pyx
+++ b/cherab/core/model/laser/model.pyx
@@ -38,7 +38,7 @@ cdef class SeldenMatobaThomsonSpectrum(LaserModel):
     of the scattered laser light c is calculated as a sum of contributions of all laser wavelengths
 
     .. math::
-         c(\lambda) =  c r_e^2 n_e cos^2\\theta \\sum_{\\lambda_L} \\frac{E_L(\\lambda_l) S(\\frac{\\lambda}{\\lambda_L} - 1, \\varphi, T_e)}{\\lambda_L},
+         c(\\lambda) =  c r_e^2 n_e cos^2\\theta \\sum_{\\lambda_L} \\frac{E_L(\\lambda_l) S(\\frac{\\lambda}{\\lambda_L} - 1, \\varphi, T_e)}{\\lambda_L},
     
 
     where :math:`\\lambda` is the spectrum's wavelength, :math:`r_e` is the classical electron radius, :math:`n_e` is the electron delsity,

--- a/cherab/core/model/laser/model.pyx
+++ b/cherab/core/model/laser/model.pyx
@@ -30,7 +30,7 @@ from cherab.core.utility.constants cimport SPEED_OF_LIGHT, ELECTRON_CLASSICAL_RA
 
 
 cdef class SeldenMatobaThomsonSpectrum(LaserModel):
-    """
+    r"""
     Thomson Scattering based on Selden-Matoba.
 
     The class calculates Thomson scattering of the laser to the spectrum. The model of the scattered spectrum used is based on
@@ -38,7 +38,7 @@ cdef class SeldenMatobaThomsonSpectrum(LaserModel):
     of the scattered laser light c is calculated as a sum of contributions of all laser wavelengths
 
     .. math::
-         c(\\lambda) =  c r_e^2 n_e cos^2\\theta \\sum_{\\lambda_L} \\frac{E_L(\\lambda_l) S(\\frac{\\lambda}{\\lambda_L} - 1, \\varphi, T_e)}{\\lambda_L},
+         c(\lambda) =  c r_e^2 n_e cos^2\\theta \\sum_{\\lambda_L} \\frac{E_L(\\lambda_l) S(\\frac{\\lambda}{\\lambda_L} - 1, \\varphi, T_e)}{\\lambda_L},
     
 
     where :math:`\\lambda` is the spectrum's wavelength, :math:`r_e` is the classical electron radius, :math:`n_e` is the electron delsity,

--- a/cherab/core/plasma/node.pyx
+++ b/cherab/core/plasma/node.pyx
@@ -394,7 +394,7 @@ cdef class Plasma(Node):
 
     @cython.cdivision(True)
     cpdef double z_effective(self, double x, double y, double z) except -1:
-        """
+        r"""
         Calculates the effective Z of the plasma.
 
         .. math::
@@ -435,7 +435,7 @@ cdef class Plasma(Node):
     @cython.boundscheck(False)
     @cython.wraparound(False)
     cpdef double ion_density(self, double x, double y, double z):
-        """
+        r"""
         Calculates the total ion density of the plasma.
 
         .. math::

--- a/cherab/generomak/plasma/plasma.py
+++ b/cherab/generomak/plasma/plasma.py
@@ -305,7 +305,7 @@ def get_double_parabola(v_min, v_max, convexity, concavity, xmin=0, xmax=1):
 
 
 def get_exponential_growth(initial_value, growth_rate, initial_position=1):
-    """
+    r"""
     returns exponentially growing Function1D
 
     The returned Function1D is of the form:

--- a/cherab/tools/emitters/radiation_function.pyx
+++ b/cherab/tools/emitters/radiation_function.pyx
@@ -24,7 +24,7 @@ cimport cython
 
 
 cdef class RadiationFunction(InhomogeneousVolumeEmitter):
-    """
+    r"""
     A general purpose radiation material.
 
     Radiates power over 4 pi according to the supplied 3D radiation

--- a/cherab/tools/equilibrium/efit.pyx
+++ b/cherab/tools/equilibrium/efit.pyx
@@ -36,7 +36,7 @@ from cherab.core.math cimport IsoMapper2D, AxisymmetricMapper, VectorAxisymmetri
 from cherab.core.math cimport ClampOutput2D
 
 cdef class EFITEquilibrium:
-    """
+    r"""
     An object representing an EFIT equilibrium time-slice.
 
     EFIT is a code commonly used throughout the Fusion research community
@@ -278,7 +278,7 @@ cdef class EFITEquilibrium:
         return AxisymmetricMapper(self.map2d(profile, value_outside_lcfs))
 
     def map_vector2d(self, object toroidal, object poloidal, object normal, Vector3D value_outside_lcfs=None):
-        """
+        r"""
         Maps velocity components in flux coordinates onto flux surfaces in the r-z plane.
 
         It is often convenient to express the plasma velocity components in flux coordinates,
@@ -344,7 +344,7 @@ cdef class EFITEquilibrium:
         return VectorBlend2D(value_outside_lcfs, v, self.inside_lcfs)
 
     def map_vector3d(self, object toroidal, object poloidal, object normal, Vector3D value_outside_lcfs=None):
-        """
+        r"""
         Maps velocity components in flux coordinates onto flux surfaces in 3D space.
 
         It is often convenient to express the plasma velocity components in flux coordinates,

--- a/cherab/tools/inversions/lstsq.py
+++ b/cherab/tools/inversions/lstsq.py
@@ -21,7 +21,7 @@ import numpy as np
 
 
 def invert_regularised_lstsq(w_matrix, b_vector, alpha=0.01, tikhonov_matrix=None):
-    """
+    r"""
     Solves :math:`\mathbf{b} = \mathbf{W} \mathbf{x}` for the vector :math:`\mathbf{x}`,
     using Tikhonov regulariastion.
 

--- a/cherab/tools/inversions/sart.pyx
+++ b/cherab/tools/inversions/sart.pyx
@@ -25,7 +25,7 @@ cimport cython
 @cython.boundscheck(False)
 cpdef invert_sart(geometry_matrix, measurement_vector, object initial_guess=None, int max_iterations=250,
                   double relaxation=1.0, double conv_tol=1.0E-4):
-    """
+    r"""
     Performs a SART inversion on the specified measurement vector.
     
     This function implements the Simultaneous Algebraic Reconstruction Technique (SART), as published in
@@ -161,7 +161,7 @@ cpdef invert_sart(geometry_matrix, measurement_vector, object initial_guess=None
 cpdef invert_constrained_sart(geometry_matrix, laplacian_matrix, measurement_vector,
                               object initial_guess=None, int max_iterations=250, double relaxation=1.0,
                               double beta_laplace=0.01, double conv_tol=1.0E-4):
-    """
+    r"""
 
     Performs a constrained SART inversion on the specified measurement vector.
     

--- a/cherab/tools/raytransfer/emitters.pyx
+++ b/cherab/tools/raytransfer/emitters.pyx
@@ -71,7 +71,7 @@ cdef class RayTransferIntegrator(VolumeIntegrator):
 
 
 cdef class CylindricalRayTransferIntegrator(RayTransferIntegrator):
-    """
+    r"""
     Calculates the distances traveled by the ray through the voxels defined on a regular grid
     in cylindrical coordinate system: :math:`(R, \phi, Z)`. This integrator is used
     with the `CylindricalRayTransferEmitter` material class to calculate ray transfer matrices
@@ -338,7 +338,7 @@ cdef class RayTransferEmitter(InhomogeneousVolumeEmitter):
 
 
 cdef class CylindricalRayTransferEmitter(RayTransferEmitter):
-    """
+    r"""
     A unit emitter defined on a regular 3D :math:`(R, \phi, Z)` grid, which
     can be used to calculate ray transfer matrices (geometry matrices) for a single value
     of wavelength.

--- a/cherab/tools/raytransfer/raytransfer.py
+++ b/cherab/tools/raytransfer/raytransfer.py
@@ -127,7 +127,7 @@ class RayTransferObject:
 
 
 class RayTransferCylinder(RayTransferObject):
-    """
+    r"""
     Ray transfer object for cylindrical emitter defined on a regular 3D :math:`(R, \phi, Z)` grid.
     This emitter is periodic in :math:`\phi` direction.
     The base of the cylinder is located at `Z = 0` plane. Use `transform`


### PR DESCRIPTION
It looks like issue #460 also affects docstings. Hopefully I found all docstrings with escape characters in Cherab without _r_ prefix.