### PR TITLE
Change Raysect version to 0.8.1.* in dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install Python dependencies
       run: python -m pip install --prefer-binary cython~=3.0 ${{ matrix.numpy-version }} scipy matplotlib "pyopencl[pocl]>=2022.2.4"
     - name: Install Raysect from pypi
-      run: pip install raysect==0.8.1
+      run: pip install raysect==0.8.1.*
     - name: Build cherab
       run: dev/build.sh
     - name: Run tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=62.3", "oldest-supported-numpy", "cython~=3.0", "raysect==0.8.1"]
+requires = ["setuptools>=62.3", "oldest-supported-numpy", "cython~=3.0", "raysect==0.8.1.*"]
 build-backend="setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ cython~=3.0
 numpy>=1.14,<2.0
 scipy
 matplotlib
-raysect==0.8.1
+raysect==0.8.1.*

--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,7 @@ setup(
         "numpy>=1.14,<2.0",
         "scipy",
         "matplotlib",
-        "raysect==0.8.1",
+        "raysect==0.8.1.*",
     ],
     extras_require={
         # Running ./dev/build_docs.sh runs setup.py, which requires cython.


### PR DESCRIPTION
This fixes #459 by changing `raysect==0.8.1` to `raysect==0.8.1.*` in dependencies to install Raysect post-releases.