### PR TITLE
Run CI on ubuntu 22.04 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   tests:
     name: Run tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04  # Needed for Python 3.7 compatibility
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
ubuntu-latest switched to 24.04, but 22.04 is the last version which supports Python 3.7 that we continue to test against for now.