### PR TITLE
feat: Add linting and formating config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,30 @@ line-length = 120
 include = ["cherab/**/*.py", "demos/**/*.py"]
 
 [tool.ruff.lint]
-ignore = [
-    "F401",  # ignore unused imports
+select = [
+  "E",   # pycodestyle
+  "B",   # flake8-bugbear
+  "F",   # pyflakes
+  "I",   # isort (import order)
+  "N",   # pep8-naming
+  "W",   # Warning
+  "UP",  # pyupgrade
+  "NPY", # numpy specific rules
+  "D",   # pydocstyle
+  "DOC", # pydoclint
 ]
+preview = true
+ignore = [
+  # Recommended ignores by ruff when using formatter
+  "E501", # line too long
+  "N803", # argument name should be lowercase
+  "N806", # variable in function should be lowercase
+  "D107", # missing docstring in __init__
+  "F401", # ignore unused imports
+]
+
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"
 
 [tool.cython-lint]
 max-line-length = 140

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,15 @@
 [build-system]
 requires = ["setuptools>=62.3", "oldest-supported-numpy", "cython~=3.0", "raysect==0.8.1.*"]
 build-backend="setuptools.build_meta"
+
+[tool.ruff]
+line-length = 120
+include = ["cherab/**/*.py", "demos/**/*.py"]
+
+[tool.ruff.lint]
+ignore = [
+    "F401",  # ignore unused imports
+]
+
+[tool.cython-lint]
+max-line-length = 140


### PR DESCRIPTION
# Motivation
To maintain clear and readable code, we should use linting and formatting settings.

# Tools to adopt
- [`ruff`](https://github.com/astral-sh/ruff) — Python de fact standard linter/formatter
- [`cython-lint`](https://github.com/MarcoGorelli/cython-lint) — Cython linter
- [`dprint`](https://github.com/dprint/dprint) — code formatting platform mainly to format `yaml`, `json`, `markdown` files

## pre-commit tool
- [`lefthook`](https://github.com/evilmartians/lefthook) — Git hooks manager to execute all of the above checks before commit or when CI runs.

# Note
I assume that these tools can be managed by a package management system like `pixi`. (#489)

Finally, I would be happy to discuss the most appropriate approach for `cherab` developers.