### PR TITLE
Introduce indexed ray transfer APIs and tests

### DIFF
--- a/cherab/tools/raytransfer/emitters.pxd
+++ b/cherab/tools/raytransfer/emitters.pxd
@@ -19,6 +19,7 @@
 # under the Licence
 
 from numpy cimport ndarray
+from raysect.core.math.function.float.function3d cimport Function3D
 from raysect.optical cimport World, Primitive, Ray, Spectrum, Point3D, Vector3D, AffineMatrix3D
 from raysect.optical.material cimport VolumeIntegrator, InhomogeneousVolumeEmitter
 
@@ -38,6 +39,13 @@ cdef class CylindricalRayTransferIntegrator(RayTransferIntegrator):
 
 
 cdef class CartesianRayTransferIntegrator(RayTransferIntegrator):
+
+    cpdef Spectrum integrate(self, Spectrum spectrum, World world, Ray ray, Primitive primitive,
+                             InhomogeneousVolumeEmitter material, Point3D start_point, Point3D end_point,
+                             AffineMatrix3D world_to_primitive, AffineMatrix3D primitive_to_world)
+
+
+cdef class IndexedRayTransferIntegrator(RayTransferIntegrator):
 
     cpdef Spectrum integrate(self, Spectrum spectrum, World world, Ray ray, Primitive primitive,
                              InhomogeneousVolumeEmitter material, Point3D start_point, Point3D end_point,
@@ -71,6 +79,17 @@ cdef class CartesianRayTransferEmitter(RayTransferEmitter):
 
     cdef:
         double _dx, _dy, _dz
+
+    cpdef Spectrum emission_function(self, Point3D point, Vector3D direction, Spectrum spectrum,
+                                     World world, Ray ray, Primitive primitive,
+                                     AffineMatrix3D world_to_primitive, AffineMatrix3D primitive_to_world)
+
+
+cdef class IndexedRayTransferEmitter(InhomogeneousVolumeEmitter):
+
+    cdef:
+        Function3D index_function
+        int _bins
 
     cpdef Spectrum emission_function(self, Point3D point, Vector3D direction, Spectrum spectrum,
                                      World world, Ray ray, Primitive primitive,

--- a/cherab/tools/raytransfer/emitters.pxd
+++ b/cherab/tools/raytransfer/emitters.pxd
@@ -88,7 +88,7 @@ cdef class CartesianRayTransferEmitter(RayTransferEmitter):
 cdef class IndexedRayTransferEmitter(InhomogeneousVolumeEmitter):
 
     cdef:
-        Function3D index_function
+        public Function3D index_function
         int _bins
 
     cpdef Spectrum emission_function(self, Point3D point, Vector3D direction, Spectrum spectrum,

--- a/cherab/tools/raytransfer/emitters.pyx
+++ b/cherab/tools/raytransfer/emitters.pyx
@@ -25,7 +25,7 @@ with other integrators is not guaranteed.
 """
 
 import numpy as np
-from raysect.core.math.function.float.function3d cimport autowrap_function3d
+from raysect.core.math.function.float.function3d cimport autowrap_function3d, Function3D
 from raysect.optical cimport World, Primitive, Ray, Spectrum, Point3D, Vector3D, AffineMatrix3D
 from raysect.optical.material cimport VolumeIntegrator, InhomogeneousVolumeEmitter
 from libc.math cimport sqrt, atan2, M_PI as pi
@@ -263,6 +263,7 @@ cdef class IndexedRayTransferIntegrator(RayTransferIntegrator):
             Vector3D direction
             int isource_pre, isource_current, it, n
             double length, t, dt, x, y, z, res
+            Function3D index_function
 
         if not isinstance(material, IndexedRayTransferEmitter):
             raise TypeError(
@@ -281,6 +282,7 @@ cdef class IndexedRayTransferIntegrator(RayTransferIntegrator):
         dt = length / n  # integration step
         # cython performs checks on attributes of external class,
         # so it's better to do the checks before the loop
+        index_function = material.index_function
         isource_current = -1
         isource_pre = -1
         res = 0
@@ -289,7 +291,7 @@ cdef class IndexedRayTransferIntegrator(RayTransferIntegrator):
             x = start.x + direction.x * t  # x coordinates of the points
             y = start.y + direction.y * t  # y coordinates of the points
             z = start.z + direction.z * t  # z coordinates of the points
-            isource_current = <int>material.index_function(x, y, z)  # get geometry grid index
+            isource_current = <int>index_function(x, y, z)  # get geometry grid index
             if isource_current != isource_pre:  # we moved to the next cell
                 if isource_pre > -1:
                     # writing results for the current source
@@ -655,17 +657,23 @@ cdef class IndexedRayTransferEmitter(InhomogeneousVolumeEmitter):
     """A unit emitter defined by an index function, which can be used
     to calculate ray transfer matrices (geometry matrices).
 
+    This approach is suitable for arbitrary source geometries defined via a callable,
+    for example the 3D application in
+    `K. Munechika et al., Rev. Sci. Instrum. 96, 043509 (2024) <https://doi.org/10.1063/5.0225703>`_.
+
     Note that for performance reason there are no boundary checks in `emission_function()`,
     or in `IndexedRayTransferIntegrator`,
     so this emitter must be placed inside a bounding box.
 
     :param callable index_function: Callable objects taking 3 positional arguments :math:`(X, Y, Z)`.
+        This function should return an integer value; any fractional part will be discarded.
     :param int bins: Number of bins for the spectral array, by default 0.
     :param float integration_step: The length of line integration step, by default 0.01.
     :param VolumeIntegrator integrator: Volume integrator, by default `.IndexedRayTransferIntegrator(integration_step)`.
         Volume integrator, by default `.IndexedRayTransferIntegrator(integration_step)`.
 
     :ivar callable index_function: Callable objects taking 3 positional arguments :math:`(X, Y, Z)`.
+        This function should return an integer value; any fractional part will be discarded.
     :ivar int bins: Number of bins for the spectral array.
 
     .. code-block:: python

--- a/cherab/tools/raytransfer/emitters.pyx
+++ b/cherab/tools/raytransfer/emitters.pyx
@@ -25,6 +25,7 @@ with other integrators is not guaranteed.
 """
 
 import numpy as np
+from raysect.core.math.function.float.function3d cimport Function3D, autowrap_function3d
 from raysect.optical cimport World, Primitive, Ray, Spectrum, Point3D, Vector3D, AffineMatrix3D
 from raysect.optical.material cimport VolumeIntegrator, InhomogeneousVolumeEmitter
 from libc.math cimport sqrt, atan2, M_PI as pi
@@ -216,6 +217,89 @@ cdef class CartesianRayTransferIntegrator(RayTransferIntegrator):
                         spectrum.samples_mv[isource_current] += res  # writing results for the current source
                     isource_current = isource
                     res = 0
+            if isource_current > -1:
+                res += dt
+        if isource_current > -1:
+            spectrum.samples_mv[isource_current] += res
+
+        return spectrum
+
+
+
+cdef class IndexedRayTransferIntegrator(RayTransferIntegrator):
+    """Calculates the distances traveled by the ray through indexed regions in 3D coordinate system: :math:`(X, Y, Z)`.
+
+    This integrator is used with the `IndexedRayTransferEmitter` material class and
+    an index function to calculate ray transfer matrices (geometry matrices).
+    The value for each voxel is stored in respective bin of the spectral array.
+    The distances traveled by the ray through the voxel is calculated
+    approximately and the accuracy depends on the integration step.
+
+    Parameters
+    ----------
+    step : float
+        Integration step, by default 0.001.
+    min_samples : int
+        Number of minimum samples of integration, by default 2.
+    """
+    def __init__(self, double step=0.001, int min_samples=2):
+        super().__init__(step=step, min_samples=min_samples)
+
+    @cython.wraparound(False)
+    @cython.cdivision(True)
+    @cython.initializedcheck(False)
+    @cython.nonecheck(False)
+    cpdef Spectrum integrate(
+        self,
+        Spectrum spectrum,
+        World world,
+        Ray ray,
+        Primitive primitive,
+        InhomogeneousVolumeEmitter material,
+        Point3D start_point,
+        Point3D end_point,
+        AffineMatrix3D world_to_primitive,
+        AffineMatrix3D primitive_to_world
+    ):
+
+        cdef:
+            Point3D start, end
+            Vector3D direction
+            int isource_pre, isource_current, it, n
+            double length, t, dt, x, y, z, res
+
+        if not isinstance(material, IndexedRayTransferEmitter):
+            raise TypeError(
+                'Only IndexedRayTransferEmitter material is supported '
+                'by IndexedRayTransferIntegrator'
+            )
+        start = start_point  # start point in world coordinates
+        end = end_point  # end point in world coordinates
+        direction = start.vector_to(end)  # direction of integration
+        length = direction.get_length()  # integration length
+        if length < 0.1 * self._step:  # return if ray's path is too short
+            return spectrum
+        direction = direction.normalise()  # normalized direction
+        # number of points along ray's trajectory
+        n = max(self._min_samples, <int>(length / self._step))
+        dt = length / n  # integration step
+        # cython performs checks on attributes of external class,
+        # so it's better to do the checks before the loop
+        isource_current = -1
+        isource_pre = -1
+        res = 0
+        for it in range(n):
+            t = (it + 0.5) * dt
+            x = start.x + direction.x * t  # x coordinates of the points
+            y = start.y + direction.y * t  # y coordinates of the points
+            z = start.z + direction.z * t  # z coordinates of the points
+            isource_current = <int>material.index_function(x, y, z)  # get geometry grid index
+            if isource_current != isource_pre:  # we moved to the next cell
+                if isource_pre > -1:
+                    # writing results for the current source
+                    spectrum.samples_mv[isource_pre] += res
+                isource_pre = isource_current
+                res = 0
             if isource_current > -1:
                 res += dt
         if isource_current > -1:
@@ -565,6 +649,116 @@ cdef class CartesianRayTransferEmitter(RayTransferEmitter):
         iy = <int>(point.y / self._dy)  # Y-index of grid cell, in which the point is located
         iz = <int>(point.z / self._dz)  # Z-index of grid cell, in which the point is located
         isource = self.voxel_map_mv[ix, iy, iz]  # index of the light source in spectral array
+        if isource < 0:  # grid cell is not mapped to any light source
+            return spectrum
+        spectrum.samples_mv[isource] += 1.  # unit emissivity
+        return spectrum
+
+
+cdef class IndexedRayTransferEmitter(InhomogeneousVolumeEmitter):
+    """A unit emitter defined by an index function, which can be used
+    to calculate ray transfer matrices (geometry matrices).
+
+    Note that for performance reason there are no boundary checks in `emission_function()`,
+    or in `IndexedRayTransferIntegrator`,
+    so this emitter must be placed inside a bounding box.
+
+    Parameters
+    ----------
+    index_function : callable
+        Callable objects taking 3 positional arguments :math:`(X, Y, Z)`.
+    bins : int
+        Number of bins for the spectral array, by default 0.
+    integration_step : float
+        The length of line integration step, by default 0.01.
+    integrator : :obj:`~raysect.optical.material.emitter.inhomogeneous.VolumeIntegrator`
+        Volume integrator, by default `.IndexedRayTransferIntegrator(integration_step)`.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        from numpy import hypot
+        from raysect.optical import World, translate, Point3D
+        from raysect.primitive import Cylinder
+        from cherab.tools.raytransfer import IndexedRayTransferEmitter
+
+        def index_func(x, y, z):
+            if hypot(x, y) <= 1:
+                return 0
+            elif 1 < hypot(x, y) <= 2:
+                return 1
+            else:
+                return -1  # must be set -1 outside meshes.
+
+        world = World()
+        bins = 2  # Note that bins must be same as the number of meshes.
+                  # Here thinking of two meshes like bins.shape = (2, ).
+        material = IndexedRayTransferEmitter(index_func, bins, integration_step=0.001)
+        eps = 1.e-6  # ray must never leave the grid when passing through the volume
+        radius = 2.0 - eps
+        height = 10.0
+        cylinder = Cylinder(
+            radius,
+            height,
+            material=material,
+            parent=world,
+            transform=translate(0, 0, -0.5 * height)
+        )
+
+        camera.spectral_bins = material.bins
+        # ray transfer matrix will be calculated for 600.5 nm
+        camera.min_wavelength = 600.
+        camera.max_wavelength = 601.
+    """
+
+    cdef:
+        readonly Function3D index_function
+        readonly int _bins
+
+    def __init__(
+        self,
+        object index_function not None,
+        int bins=0,
+        double integration_step=0.01,
+        VolumeIntegrator integrator=None
+    ):
+
+        integrator = integrator or IndexedRayTransferIntegrator(step=integration_step)
+        super().__init__(integrator=integrator)
+
+        self.index_function = autowrap_function3d(index_function)
+        self._bins = bins
+
+    @property
+    def bins(self):
+        """
+        Number of indexed regions, must not exceed the maximum of `index_function`.
+
+        :rtype: int
+        """
+        return self._bins
+
+    @cython.wraparound(False)
+    @cython.cdivision(True)
+    @cython.initializedcheck(False)
+    @cython.nonecheck(False)
+    cpdef Spectrum emission_function(
+        self, Point3D point,
+        Vector3D direction,
+        Spectrum spectrum,
+        World world,
+        Ray ray,
+        Primitive primitive,
+        AffineMatrix3D world_to_primitive,
+        AffineMatrix3D primitive_to_world
+    ):
+
+        cdef:
+            int isource
+
+        # index of the light source for the current region
+        isource = <int>self.index_function(point.x, point.y, point.z)
         if isource < 0:  # grid cell is not mapped to any light source
             return spectrum
         spectrum.samples_mv[isource] += 1.  # unit emissivity

--- a/cherab/tools/raytransfer/emitters.pyx
+++ b/cherab/tools/raytransfer/emitters.pyx
@@ -235,12 +235,8 @@ cdef class IndexedRayTransferIntegrator(RayTransferIntegrator):
     The distances traveled by the ray through the voxel is calculated
     approximately and the accuracy depends on the integration step.
 
-    Parameters
-    ----------
-    step : float
-        Integration step, by default 0.001.
-    min_samples : int
-        Number of minimum samples of integration, by default 2.
+    :param float step: Integration step, by default 0.001.
+    :param int min_samples: Number of minimum samples of integration, by default 2.
     """
     def __init__(self, double step=0.001, int min_samples=2):
         super().__init__(step=step, min_samples=min_samples)
@@ -663,19 +659,15 @@ cdef class IndexedRayTransferEmitter(InhomogeneousVolumeEmitter):
     or in `IndexedRayTransferIntegrator`,
     so this emitter must be placed inside a bounding box.
 
-    Parameters
-    ----------
-    index_function : callable
-        Callable objects taking 3 positional arguments :math:`(X, Y, Z)`.
-    bins : int
-        Number of bins for the spectral array, by default 0.
-    integration_step : float
-        The length of line integration step, by default 0.01.
-    integrator : :obj:`~raysect.optical.material.emitter.inhomogeneous.VolumeIntegrator`
+    :param callable index_function: Callable objects taking 3 positional arguments :math:`(X, Y, Z)`.
+    :param int bins: Number of bins for the spectral array, by default 0.
+    :param float integration_step: The length of line integration step, by default 0.01.
+    :param VolumeIntegrator integrator: Volume integrator, by default `.IndexedRayTransferIntegrator(integration_step)`.
         Volume integrator, by default `.IndexedRayTransferIntegrator(integration_step)`.
 
-    Examples
-    --------
+    :ivar callable index_function: Callable objects taking 3 positional arguments :math:`(X, Y, Z)`.
+    :ivar int bins: Number of bins for the spectral array.
+
     .. code-block:: python
 
         from numpy import hypot

--- a/cherab/tools/raytransfer/emitters.pyx
+++ b/cherab/tools/raytransfer/emitters.pyx
@@ -25,7 +25,7 @@ with other integrators is not guaranteed.
 """
 
 import numpy as np
-from raysect.core.math.function.float.function3d cimport Function3D, autowrap_function3d
+from raysect.core.math.function.float.function3d cimport autowrap_function3d
 from raysect.optical cimport World, Primitive, Ray, Spectrum, Point3D, Vector3D, AffineMatrix3D
 from raysect.optical.material cimport VolumeIntegrator, InhomogeneousVolumeEmitter
 from libc.math cimport sqrt, atan2, M_PI as pi
@@ -711,10 +711,6 @@ cdef class IndexedRayTransferEmitter(InhomogeneousVolumeEmitter):
         camera.min_wavelength = 600.
         camera.max_wavelength = 601.
     """
-
-    cdef:
-        readonly Function3D index_function
-        readonly int _bins
 
     def __init__(
         self,

--- a/cherab/tools/raytransfer/emitters.pyx
+++ b/cherab/tools/raytransfer/emitters.pyx
@@ -670,7 +670,6 @@ cdef class IndexedRayTransferEmitter(InhomogeneousVolumeEmitter):
     :param int bins: Number of bins for the spectral array, by default 0.
     :param float integration_step: The length of line integration step, by default 0.01.
     :param VolumeIntegrator integrator: Volume integrator, by default `.IndexedRayTransferIntegrator(integration_step)`.
-        Volume integrator, by default `.IndexedRayTransferIntegrator(integration_step)`.
 
     :ivar callable index_function: Callable objects taking 3 positional arguments :math:`(X, Y, Z)`.
         This function should return an integer value; any fractional part will be discarded.

--- a/cherab/tools/raytransfer/emitters.pyx
+++ b/cherab/tools/raytransfer/emitters.pyx
@@ -659,7 +659,7 @@ cdef class IndexedRayTransferEmitter(InhomogeneousVolumeEmitter):
 
     This approach is suitable for arbitrary source geometries defined via a callable,
     for example the 3D application in
-    `K. Munechika et al., Rev. Sci. Instrum. 96, 043509 (2024) <https://doi.org/10.1063/5.0225703>`_.
+    `K. Munechika et al., Rev. Sci. Instrum. 96, 043509 (2025) <https://doi.org/10.1063/5.0225703>`_.
 
     Note that for performance reason there are no boundary checks in `emission_function()`,
     or in `IndexedRayTransferIntegrator`,

--- a/cherab/tools/tests/test_raytransfer.py
+++ b/cherab/tools/tests/test_raytransfer.py
@@ -17,12 +17,24 @@
 # under the Licence.
 
 import unittest
+
 import numpy as np
-from raysect.optical import World, Ray, Point3D, Point2D, Vector3D, NumericalIntegrator, Spectrum
+from raysect.core.math.function.float.function3d.interpolate import Discrete3DMesh
+from raysect.optical import NumericalIntegrator, Point2D, Point3D, Ray, Spectrum, Vector3D, World
 from raysect.primitive import Box, Cylinder, Subtract
-from cherab.tools.raytransfer import RayTransferBox, RayTransferCylinder, CartesianRayTransferEmitter, CylindricalRayTransferEmitter
-from cherab.tools.raytransfer import RayTransferPipeline0D, RayTransferPipeline1D, RayTransferPipeline2D
+
 from cherab.tools.inversions import ToroidalVoxelGrid
+from cherab.tools.raytransfer import (
+    CartesianRayTransferEmitter,
+    CylindricalRayTransferEmitter,
+    IndexedRayTransferEmitter,
+    IndexedRayTransferIntegrator,
+    RayTransferBox,
+    RayTransferCylinder,
+    RayTransferPipeline0D,
+    RayTransferPipeline1D,
+    RayTransferPipeline2D,
+)
 
 
 class TestRayTransferCylinder(unittest.TestCase):
@@ -89,7 +101,7 @@ class TestRayTransferCylinder(unittest.TestCase):
         self.assertTrue(np.all(mask_ref == rtc.mask) and np.all(np.array(inv_vmap_ref) == np.array(rtc.invert_voxel_map())) and rtc.bins == 8)
 
     def test_integration_2d(self):
-        """ Testing against ToroidalVoxelGrid"""
+        """Testing against ToroidalVoxelGrid"""
         world = World()
         rtc = RayTransferCylinder(radius_outer=4., height=2., n_radius=2, n_height=2, radius_inner=2., parent=world)
         rtc.step = 0.001 * rtc.step
@@ -240,6 +252,125 @@ class TestCylindricalRayTransferEmitter(unittest.TestCase):
         spectrum_test = np.zeros(12)
         spectrum_test[2] = spectrum_test[9] = np.sqrt(2.)
         self.assertTrue(np.allclose(spectrum_test, spectrum.samples, atol=0.001))
+
+
+class TestIndexedRayTransferEmitter(unittest.TestCase):
+    """
+    Test cases for IndexedRayTransferEmitter class.
+    """
+
+    @staticmethod
+    def index_func(x, y, z):
+        if 0 <= x < 3 and 0 <= y < 3 and 0 <= z < 3:
+            return int(x) + 3 * int(y) + 9 * int(z)
+        return -1
+
+    @staticmethod
+    def _vertex_index(i, j, k):
+        return i + 4 * j + 16 * k
+
+    @classmethod
+    def _build_discrete3dmesh_index_function(cls):
+        # 4x4x4 grid vertices covering a 3x3x3 set of unit cells.
+        vertex_coords = np.array(
+            [[float(i), float(j), float(k)] for k in range(4) for j in range(4) for i in range(4)],
+            dtype=np.float64,
+        )
+
+        tetrahedra = []
+        tetrahedra_data = []
+        for i, j, k in np.ndindex(3, 3, 3):
+            cell_value = float(i + 3 * j + 9 * k)
+            v000 = cls._vertex_index(i, j, k)
+            v100 = cls._vertex_index(i + 1, j, k)
+            v010 = cls._vertex_index(i, j + 1, k)
+            v110 = cls._vertex_index(i + 1, j + 1, k)
+            v001 = cls._vertex_index(i, j, k + 1)
+            v101 = cls._vertex_index(i + 1, j, k + 1)
+            v011 = cls._vertex_index(i, j + 1, k + 1)
+            v111 = cls._vertex_index(i + 1, j + 1, k + 1)
+
+            # Split each cube into 6 tetrahedra using the 000 -> 111 body diagonal.
+            tetrahedra.extend(
+                [
+                    [v000, v100, v110, v111],
+                    [v000, v100, v101, v111],
+                    [v000, v001, v101, v111],
+                    [v000, v001, v011, v111],
+                    [v000, v010, v011, v111],
+                    [v000, v010, v110, v111],
+                ]
+            )
+            tetrahedra_data.extend([cell_value] * 6)
+
+        return Discrete3DMesh(
+            vertex_coords,
+            np.array(tetrahedra, dtype=np.int32),
+            np.array(tetrahedra_data, dtype=np.float64),
+            limit=False,
+            default_value=-1.0,
+        )
+
+    def test_evaluate_function(self):
+        """
+        Test IndexedRayTransferEmitter with NumericalIntegrator.
+        """
+        world = World()
+        material = IndexedRayTransferEmitter(self.index_func, bins=27, integrator=NumericalIntegrator(0.0001))
+        box = Box(lower=Point3D(0, 0, 0), upper=Point3D(2.99999, 2.99999, 2.99999), material=material, parent=world)
+        ray = Ray(origin=Point3D(4.0, 4.0, 4.0), direction=Vector3D(-1.0, -1.0, -1.0) / np.sqrt(3), min_wavelength=500.0, max_wavelength=501.0, bins=material.bins)
+        spectrum = ray.trace(world)
+        spectrum_test = np.zeros(material.bins)
+        spectrum_test[0] = spectrum_test[13] = spectrum_test[26] = np.sqrt(3.0)
+        self.assertTrue(np.allclose(spectrum_test, spectrum.samples, atol=0.001))
+
+    def test_default_integrator(self):
+        """
+        Test IndexedRayTransferEmitter with IndexedRayTransferIntegrator.
+        """
+        world = World()
+        material = IndexedRayTransferEmitter(self.index_func, bins=27)
+        self.assertTrue(isinstance(material.integrator, IndexedRayTransferIntegrator))
+        box = Box(lower=Point3D(0, 0, 0), upper=Point3D(2.99999, 2.99999, 2.99999), material=material, parent=world)
+        ray = Ray(origin=Point3D(4.0, 4.0, 4.0), direction=Vector3D(-1.0, -1.0, -1.0) / np.sqrt(3), min_wavelength=500.0, max_wavelength=501.0, bins=material.bins)
+        spectrum = ray.trace(world)
+        spectrum_test = np.zeros(material.bins)
+        spectrum_test[0] = spectrum_test[13] = spectrum_test[26] = np.sqrt(3.0)
+        self.assertTrue(np.allclose(spectrum_test, spectrum.samples, atol=0.001))
+
+    def test_discrete3dmesh_as_index_function(self):
+        """
+        Test IndexedRayTransferEmitter with a Discrete3DMesh index function　equivalent to index_func.
+        """
+        mesh_index_func = self._build_discrete3dmesh_index_function()
+
+        # Check representative points inside all voxels and outside the domain.
+        for i, j, k in np.ndindex(3, 3, 3):
+            x, y, z = i + 0.25, j + 0.25, k + 0.25
+            self.assertEqual(int(mesh_index_func(x, y, z)), self.index_func(x, y, z))
+        self.assertEqual(int(mesh_index_func(-0.1, 1.0, 1.0)), -1)
+        self.assertEqual(int(mesh_index_func(3.1, 1.0, 1.0)), -1)
+
+        # Check equivalent ray transfer matrix row from both index functions.
+        ray = Ray(
+            origin=Point3D(4.0, 4.0, 4.0),
+            direction=Vector3D(-1.0, -1.0, -1.0) / np.sqrt(3),
+            min_wavelength=500.0,
+            max_wavelength=501.0,
+            bins=27,
+        )
+
+        world_ref = World()
+        material_ref = IndexedRayTransferEmitter(self.index_func, bins=27, integrator=NumericalIntegrator(0.0001))
+        box_ref = Box(lower=Point3D(0, 0, 0), upper=Point3D(2.99999, 2.99999, 2.99999), material=material_ref, parent=world_ref)
+        spectrum_ref = ray.trace(world_ref)
+
+        world_mesh = World()
+        material_mesh = IndexedRayTransferEmitter(mesh_index_func, bins=27, integrator=NumericalIntegrator(0.0001))
+        box_mesh = Box(lower=Point3D(0, 0, 0), upper=Point3D(2.99999, 2.99999, 2.99999), material=material_mesh, parent=world_mesh)
+        spectrum_mesh = ray.trace(world_mesh)
+
+        self.assertTrue(np.allclose(spectrum_ref.samples, spectrum_mesh.samples, atol=0.001))
 
 
 class TestRayTransferPipeline0D(unittest.TestCase):

--- a/docs/source/tools/tomography.rst
+++ b/docs/source/tools/tomography.rst
@@ -65,13 +65,16 @@ Voxels
 Ray Transfer Objects
 --------------------
 
-Ray transfer objects accelerate the calculation of geometry matrices (or Ray Transfer Matrices as they were called 
-in `S. Kajita, et al. Contrib. Plasma Phys., 2016, 1-9 <https://onlinelibrary.wiley.com/doi/abs/10.1002/ctpp.201500124>`_) 
-in the case of regular spatial grids. As in the case of Voxels, the spectral array is used to store the data 
-for individual light sources (in this case the grid cells or their unions), however no voxels are created at all. 
+Ray transfer objects accelerate the calculation of geometry matrices (or Ray Transfer Matrices as they were called
+in `S. Kajita, et al. Contrib. Plasma Phys., 2016, 1-9 <https://onlinelibrary.wiley.com/doi/abs/10.1002/ctpp.201500124>`_)
+in the case of regular spatial grids. As in the case of Voxels, the spectral array is used to store the data
+for individual light sources (in this case the grid cells or their unions), however no voxels are created at all.
 Instead, a custom integration along the ray is implemented. Ray transfer objects allow to calculate geometry
-matrices for a single value of wavelength. Use `RayTransferBox` class for Cartesian grids 
+matrices for a single value of wavelength. Use `RayTransferBox` class for Cartesian grids
 and `RayTransferCylinder` class for cylindrical grids (3D or axisymmetrical).
+For arbitrary voxel shapes, use indexed ray transfer emitters where a callable index function
+maps a point in space to a source index, as used in
+`K. Munechika et al., Rev. Sci. Instrum. 96, 043509 (2025) <https://doi.org/10.1063/5.0225703>`_.
 
 Performance tips:
 
@@ -102,6 +105,10 @@ with other integrators is not guaranteed.
 .. autoclass:: cherab.tools.raytransfer.emitters.CylindricalRayTransferEmitter
 
 .. autoclass:: cherab.tools.raytransfer.emitters.CylindricalRayTransferIntegrator
+
+.. autoclass:: cherab.tools.raytransfer.emitters.IndexedRayTransferEmitter
+
+.. autoclass:: cherab.tools.raytransfer.emitters.IndexedRayTransferIntegrator
 
 **Pipelines**
 


### PR DESCRIPTION
## Summary
This PR introduces a general index-function-based ray transfer API by adding indexed emitter and integrator classes, replacing mesh-specific naming with functionality-based naming.

## Key Changes
- Added [cherab/tools/raytransfer/emitters.pyx](cherab/tools/raytransfer/emitters.pyx) implementations:
  - `IndexedRayTransferIntegrator`
  - `IndexedRayTransferEmitter`
- Updated [cherab/tools/raytransfer/emitters.pxd](cherab/tools/raytransfer/emitters.pxd) public Cython declarations for the new APIs.
- Added and updated unit tests in [cherab/tools/tests/test_raytransfer.py](cherab/tools/tests/test_raytransfer.py):
  - evaluate behavior for indexed emission/integration
  - default integrator wiring
  - `Discrete3DMesh`-backed `index_function` behavior
  - equivalent tetrahedral mesh construction checks using `numpy.ndindex` patterns

## Unit Test

| Test | Purpose | Setup | Verification | Why it matters |
|---|---|---|---|---|
| `test_evaluate_function` | Validate that `IndexedRayTransferEmitter` works correctly with `NumericalIntegrator` and maps contributions to the correct bins via `index_function`. | A 3x3x3 Box domain is used with `bins=27`. A diagonal ray crosses the volume. The index function maps in-domain points to 0..26 and returns -1 outside. | Only bins 0, 13, and 26 are non-zero, each with path-length contribution sqrt(3). The output spectrum matches the expected vector with `atol=0.001`. | Confirms correct geometric integration and bin assignment for the index-function-based workflow. |
| `test_default_integrator` | Confirm default integrator behavior when no integrator is explicitly passed. | `IndexedRayTransferEmitter` is created without an integrator argument under the same ray/volume setup as above. | The emitter uses `IndexedRayTransferIntegrator` by default, and the resulting spectrum matches the same expected vector (`atol=0.001`). | Guarantees safe default behavior and avoids mandatory integrator wiring for users. |
| `test_discrete3dmesh_as_index_function` | Validate that `Discrete3DMesh` can be used as an equivalent index function source. | A `Discrete3DMesh` is built from a 4x4x4 vertex grid over 3x3x3 cells; each cube is split into 6 tetrahedra. Cell values follow the same indexing rule as the reference index function. | Representative points across all 27 cells match the reference mapping; outside-domain points return -1; ray-transfer spectra from mesh-based and function-based indexing are equal within `atol=0.001`. | Demonstrates implementation-agnostic design and compatibility with tetrahedral mesh indexing in practical ray-transfer use. |

Executed:

    python -m unittest cherab.tools.tests.test_raytransfer.TestIndexedRayTransferEmitter -v

Result:
- `test_default_integrator`: ok
- `test_discrete3dmesh_as_index_function`: ok
- `test_evaluate_function`: ok
- Ran 3 tests, all passed.

## Example Usage

```python
from raysect.optical import World
from cherab.tools.raytransfer import IndexedRayTransferEmitter

def index_func(x, y, z):
    if x < 0:
        return 0
    return 1

world = World()
material = IndexedRayTransferEmitter(index_func, bins=2)
```

## Compatibility and Risk
- Scope is limited to ray transfer emitter/integrator API naming and related tests.
- Runtime behavior is validated by focused unit tests for indexed evaluation and Discrete3DMesh integration.

## Reviewer Notes
- Main implementation: [cherab/tools/raytransfer/emitters.pyx](cherab/tools/raytransfer/emitters.pyx)
- Public declarations: [cherab/tools/raytransfer/emitters.pxd](cherab/tools/raytransfer/emitters.pxd)
- Validation tests: [cherab/tools/tests/test_raytransfer.py](cherab/tools/tests/test_raytransfer.py)

## Checklist
- [x] API implementation updated
- [x] Cython declaration file updated
- [x] Unit tests added/updated
- [x] Targeted tests executed in pixi test environment

## Benchmark
The appendix in this paper (https://doi.org/10.1063/5.0225703) compared the raytransfer of `Discrete3D` meshes with that of regular grids, showing that the geometry matrix calculation for rectangular grids' raytransfer was much faster than the `Discrete3D` one.