### PR TITLE
Fix namespace package detection in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import os.path as path
 from pathlib import Path
 import multiprocessing
 import numpy
-from setuptools import setup, find_packages, Extension
+from setuptools import setup, find_namespace_packages, Extension
 from Cython.Build import cythonize
 
 multiprocessing.set_start_method('fork')
@@ -125,7 +125,7 @@ setup(
         # Running ./dev/build_docs.sh runs setup.py, which requires cython.
         "docs": ["cython~=3.1", "sphinx", "sphinx-rtd-theme", "sphinx-tabs"],
     },
-    packages=find_packages(include=["cherab*"]),
+    packages=find_namespace_packages(include=["cherab*"]),
     package_data={"": [
         "**/*.pyx", "**/*.pxd",  # Needed to build Cython extensions.
         "**/*.json", "**/*.cl", "**/*.npy", "**/*.obj",  # Supplementary data


### PR DESCRIPTION
Setuptools deprecated the `namespace_packages` option to `setup()`, so it was removed in #500. But `find_packages` then ignores any directories without an `__init__.py` which meant that most of the Cherab files (with the exception of the compiled .so libraries) were left out when producing a wheel.

Fix this by replacing `find_packages` with `find_namespace_packages`, which correctly handles PEP420-style namespace packages.