### PR TITLE
Fix import statement for netcdf_file in calcam.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ API changes:
 * Rename `TargettedPixelGroup` to `TargetedPixelGroup` for correct spelling. Still keep `TargettedPixelGroup` as an alias for backwards compatibility until the next major release. (#487)
 * Add emission model attribute access to line and lineshape . (#294)
 
+Bug fixes:
+* Fix the import statement for `netcdf_file` in `calcam.py` for compatibility with the upcoming `scipy` v2.0.0. (#510)
+
 New:
 * Add Function6D framework. (#478)
 * Add e_field attribute to Plasma object for electric field vector. (#465)

--- a/cherab/tools/observers/calcam.py
+++ b/cherab/tools/observers/calcam.py
@@ -18,7 +18,7 @@
 # under the Licence.
 
 import numpy as np
-from scipy.io.netcdf import netcdf_file
+from scipy.io import netcdf_file
 from raysect.core import Point3D, Vector3D
 
 


### PR DESCRIPTION
## Summary

This is the change to the `netcdf_file` import statement due to the following warning message from `scipy`:

```bash
.pixi/envs/test/lib/python3.14/site-packages/cherab/tools/observers/calcam.py:21
  /Users/koyo/Documents/cherab/imas/.pixi/envs/test/lib/python3.14/site-packages/cherab/tools/observers/calcam.py:21: DeprecationWarning: Please import `netcdf_file` from the `scipy.io` namespace; the `scipy.io.netcdf` namespace is deprecated and will be removed in SciPy 2.0.0.
    from scipy.io.netcdf import netcdf_file
```