### PR TITLE
Reorder parameters of Function6D to x,y,z,u,v,w

### DIFF
--- a/cherab/core/math/function/float/function6d/arg.pxd
+++ b/cherab/core/math/function/float/function6d/arg.pxd
@@ -21,7 +21,7 @@
 from cherab.core.math.function.float.function6d.base cimport Function6D
 
 cdef enum ArgLabel:
-    X, Y, Z, U, W, V
+    X, Y, Z, U, V, W
 
 cdef class Arg6D(Function6D):
     cdef ArgLabel _argument

--- a/cherab/core/math/function/float/function6d/arg.pyx
+++ b/cherab/core/math/function/float/function6d/arg.pyx
@@ -28,7 +28,7 @@ cdef class Arg6D(Function6D):
     This is used to pass coordinates through to other functions in the
     function framework which expect a Function6D object.
 
-    Valid options for argument are "x", "y", "z", "u", "w", or "v".
+    Valid options for argument are "x", "y", "z", "u", "v", or "w".
 
     >>> argx = Arg6D("x")
     >>> argx(2, 3, 5, 7, 11, 13)
@@ -42,14 +42,14 @@ cdef class Arg6D(Function6D):
     >>> argu = Arg6D("u")
     >>> argu(2, 3, 5, 7, 11, 13)
     7.0
-    >>> argw = Arg6D("w")
-    >>> argw(2, 3, 5, 7, 11, 13)
-    11.0
     >>> argv = Arg6D("v")
     >>> argv(2, 3, 5, 7, 11, 13)
+    11.0
+    >>> argw = Arg6D("w")
+    >>> argw(2, 3, 5, 7, 11, 13)
     13.0
 
-    :param str argument: either "x", "y", "z", "u", "w", or "v", the argument to return
+    :param str argument: either "x", "y", "z", "u", "v", or "w", the argument to return
     """
     def __init__(self, object argument):
         if argument == "x":
@@ -60,14 +60,14 @@ cdef class Arg6D(Function6D):
             self._argument = Z
         elif argument == "u":
             self._argument = U
-        elif argument == "w":
-            self._argument = W
         elif argument == "v":
             self._argument = V
+        elif argument == "w":
+            self._argument = W
         else:
-            raise ValueError("The argument to Arg6D must be either 'x', 'y', 'z', 'u', 'w' or 'v'")
+            raise ValueError("The argument to Arg6D must be either 'x', 'y', 'z', 'u', 'v' or 'w'")
 
-    cdef double evaluate(self, double x, double y, double z, double u, double w, double v) except? -1e999:
+    cdef double evaluate(self, double x, double y, double z, double u, double v, double w) except? -1e999:
         if self._argument == X:
             return x
         elif self._argument == Y:
@@ -76,7 +76,7 @@ cdef class Arg6D(Function6D):
             return z
         elif self._argument == U:
             return u
-        elif self._argument == W:
-            return w
-        else:  # V
+        elif self._argument == V:
             return v
+        else: # W
+            return w

--- a/cherab/core/math/function/float/function6d/autowrap.pyx
+++ b/cherab/core/math/function/float/function6d/autowrap.pyx
@@ -46,8 +46,8 @@ cdef class PythonFunction6D(Function6D):
     def __init__(self, object function):
         self.function = function
 
-    cdef double evaluate(self, double x, double y, double z, double u, double w, double v) except? -1e999:
-        return self.function(x, y, z, u, w, v)
+    cdef double evaluate(self, double x, double y, double z, double u, double v, double w) except? -1e999:
+        return self.function(x, y, z, u, v, w)
 
 
 cdef Function6D autowrap_function6d(object obj):

--- a/cherab/core/math/function/float/function6d/base.pxd
+++ b/cherab/core/math/function/float/function6d/base.pxd
@@ -23,7 +23,7 @@ from raysect.core.math.function.float.base cimport FloatFunction
 
 
 cdef class Function6D(FloatFunction):
-    cdef double evaluate(self, double x, double y, double z, double u, double w, double v) except? -1e999
+    cdef double evaluate(self, double x, double y, double z, double u, double v, double w) except? -1e999
 
 
 cdef class AddFunction6D(Function6D):

--- a/cherab/core/math/function/float/function6d/base.pyx
+++ b/cherab/core/math/function/float/function6d/base.pyx
@@ -40,21 +40,21 @@ cdef class Function6D(FloatFunction):
     that accepts a function object.
     """
 
-    cdef double evaluate(self, double x, double y, double z, double u, double w, double v) except? -1e999:
+    cdef double evaluate(self, double x, double y, double z, double u, double v, double w) except? -1e999:
         raise NotImplementedError("The evaluate() method has not been implemented.")
 
-    def __call__(self, double x, double y, double z, double u, double w, double v):
-        """ Evaluate the function f(x, y, z, u, w, v)
+    def __call__(self, double x, double y, double z, double u, double v, double w):
+        """ Evaluate the function f(x, y, z, u, v, w)
 
         :param float x: function parameter x
         :param float y: function parameter y
         :param float z: function parameter z
         :param float u: function parameter u
-        :param float w: function parameter w
         :param float v: function parameter v
+        :param float w: function parameter w
         :rtype: float
         """
-        return self.evaluate(x, y, z, u, w, v)
+        return self.evaluate(x, y, z, u, v, w)
     def __add__(self, object b):
         if is_callable(b):
             # a() + b()
@@ -224,8 +224,8 @@ cdef class AddFunction6D(Function6D):
         self._function1 = autowrap_function6d(function1)
         self._function2 = autowrap_function6d(function2)
 
-    cdef double evaluate(self, double x, double y, double z, double u, double w, double v) except? -1e999:
-        return self._function1.evaluate(x, y, z, u, w, v) + self._function2.evaluate(x, y, z, u, w, v)
+    cdef double evaluate(self, double x, double y, double z, double u, double v, double w) except? -1e999:
+        return self._function1.evaluate(x, y, z, u, v, w) + self._function2.evaluate(x, y, z, u, v, w)
 
 
 cdef class SubtractFunction6D(Function6D):
@@ -243,8 +243,8 @@ cdef class SubtractFunction6D(Function6D):
         self._function1 = autowrap_function6d(function1)
         self._function2 = autowrap_function6d(function2)
 
-    cdef double evaluate(self, double x, double y, double z, double u, double w, double v) except? -1e999:
-        return self._function1.evaluate(x, y, z, u, w, v) - self._function2.evaluate(x, y, z, u, w, v)
+    cdef double evaluate(self, double x, double y, double z, double u, double v, double w) except? -1e999:
+        return self._function1.evaluate(x, y, z, u, v, w) - self._function2.evaluate(x, y, z, u, v, w)
 
 
 cdef class MultiplyFunction6D(Function6D):
@@ -262,8 +262,8 @@ cdef class MultiplyFunction6D(Function6D):
         self._function1 = autowrap_function6d(function1)
         self._function2 = autowrap_function6d(function2)
 
-    cdef double evaluate(self, double x, double y, double z, double u, double w, double v) except? -1e999:
-        return self._function1.evaluate(x, y, z, u, w, v) * self._function2.evaluate(x, y, z, u, w, v)
+    cdef double evaluate(self, double x, double y, double z, double u, double v, double w) except? -1e999:
+        return self._function1.evaluate(x, y, z, u, v, w) * self._function2.evaluate(x, y, z, u, v, w)
 
 
 cdef class DivideFunction6D(Function6D):
@@ -282,11 +282,11 @@ cdef class DivideFunction6D(Function6D):
         self._function2 = autowrap_function6d(function2)
 
     @cython.cdivision(True)
-    cdef double evaluate(self, double x, double y, double z, double u, double w, double v) except? -1e999:
-        cdef double denominator = self._function2.evaluate(x, y, z, u, w, v)
+    cdef double evaluate(self, double x, double y, double z, double u, double v, double w) except? -1e999:
+        cdef double denominator = self._function2.evaluate(x, y, z, u, v, w)
         if denominator == 0.0:
             raise ZeroDivisionError("Function used as the denominator of the division returned a zero value.")
-        return self._function1.evaluate(x, y, z, u, w, v) / denominator
+        return self._function1.evaluate(x, y, z, u, v, w) / denominator
 
 
 cdef class ModuloFunction6D(Function6D):
@@ -304,11 +304,11 @@ cdef class ModuloFunction6D(Function6D):
         self._function2 = autowrap_function6d(function2)
 
     @cython.cdivision(True)
-    cdef double evaluate(self, double x, double y, double z, double u, double w, double v) except? -1e999:
-        cdef double divisor = self._function2.evaluate(x, y, z, u, w, v)
+    cdef double evaluate(self, double x, double y, double z, double u, double v, double w) except? -1e999:
+        cdef double divisor = self._function2.evaluate(x, y, z, u, v, w)
         if divisor == 0.0:
             raise ZeroDivisionError("Function used as the divisor of the modulo returned a zero value.")
-        return self._function1.evaluate(x, y, z, u, w, v) % divisor
+        return self._function1.evaluate(x, y, z, u, v, w) % divisor
 
 
 cdef class PowFunction6D(Function6D):
@@ -325,10 +325,10 @@ cdef class PowFunction6D(Function6D):
         self._function1 = autowrap_function6d(function1)
         self._function2 = autowrap_function6d(function2)
 
-    cdef double evaluate(self, double x, double y, double z, double u, double w, double v) except? -1e999:
+    cdef double evaluate(self, double x, double y, double z, double u, double v, double w) except? -1e999:
         cdef double base, exponent
-        base = self._function1.evaluate(x, y, z, u, w, v)
-        exponent = self._function2.evaluate(x, y, z, u, w, v)
+        base = self._function1.evaluate(x, y, z, u, v, w)
+        exponent = self._function2.evaluate(x, y, z, u, v, w)
         if base < 0 and floor(exponent) != exponent:  # Would return a complex value rather than double
             raise ValueError("Negative base and non-integral exponent is not supported")
         if base == 0 and exponent < 0:
@@ -348,8 +348,8 @@ cdef class AbsFunction6D(Function6D):
     def __init__(self, object function):
         self._function = autowrap_function6d(function)
 
-    cdef double evaluate(self, double x, double y, double z, double u, double w, double v) except? -1e999:
-        return abs(self._function.evaluate(x, y, z, u, w, v))
+    cdef double evaluate(self, double x, double y, double z, double u, double v, double w) except? -1e999:
+        return abs(self._function.evaluate(x, y, z, u, v, w))
 
 
 cdef class EqualsFunction6D(Function6D):
@@ -366,8 +366,8 @@ cdef class EqualsFunction6D(Function6D):
         self._function1 = autowrap_function6d(function1)
         self._function2 = autowrap_function6d(function2)
 
-    cdef double evaluate(self, double x, double y, double z, double u, double w, double v) except? -1e999:
-        return self._function1.evaluate(x, y, z, u, w, v) == self._function2.evaluate(x, y, z, u, w, v)
+    cdef double evaluate(self, double x, double y, double z, double u, double v, double w) except? -1e999:
+        return self._function1.evaluate(x, y, z, u, v, w) == self._function2.evaluate(x, y, z, u, v, w)
 
 
 cdef class NotEqualsFunction6D(Function6D):
@@ -384,8 +384,8 @@ cdef class NotEqualsFunction6D(Function6D):
         self._function1 = autowrap_function6d(function1)
         self._function2 = autowrap_function6d(function2)
 
-    cdef double evaluate(self, double x, double y, double z, double u, double w, double v) except? -1e999:
-        return self._function1.evaluate(x, y, z, u, w, v) != self._function2.evaluate(x, y, z, u, w, v)
+    cdef double evaluate(self, double x, double y, double z, double u, double v, double w) except? -1e999:
+        return self._function1.evaluate(x, y, z, u, v, w) != self._function2.evaluate(x, y, z, u, v, w)
 
 
 cdef class LessThanFunction6D(Function6D):
@@ -402,8 +402,8 @@ cdef class LessThanFunction6D(Function6D):
         self._function1 = autowrap_function6d(function1)
         self._function2 = autowrap_function6d(function2)
 
-    cdef double evaluate(self, double x, double y, double z, double u, double w, double v) except? -1e999:
-        return self._function1.evaluate(x, y, z, u, w, v) < self._function2.evaluate(x, y, z, u, w, v)
+    cdef double evaluate(self, double x, double y, double z, double u, double v, double w) except? -1e999:
+        return self._function1.evaluate(x, y, z, u, v, w) < self._function2.evaluate(x, y, z, u, v, w)
 
 
 cdef class GreaterThanFunction6D(Function6D):
@@ -420,8 +420,8 @@ cdef class GreaterThanFunction6D(Function6D):
         self._function1 = autowrap_function6d(function1)
         self._function2 = autowrap_function6d(function2)
 
-    cdef double evaluate(self, double x, double y, double z, double u, double w, double v) except? -1e999:
-        return self._function1.evaluate(x, y, z, u, w, v) > self._function2.evaluate(x, y, z, u, w, v)
+    cdef double evaluate(self, double x, double y, double z, double u, double v, double w) except? -1e999:
+        return self._function1.evaluate(x, y, z, u, v, w) > self._function2.evaluate(x, y, z, u, v, w)
 
 
 cdef class LessEqualsFunction6D(Function6D):
@@ -438,8 +438,8 @@ cdef class LessEqualsFunction6D(Function6D):
         self._function1 = autowrap_function6d(function1)
         self._function2 = autowrap_function6d(function2)
 
-    cdef double evaluate(self, double x, double y, double z, double u, double w, double v) except? -1e999:
-        return self._function1.evaluate(x, y, z, u, w, v) <= self._function2.evaluate(x, y, z, u, w, v)
+    cdef double evaluate(self, double x, double y, double z, double u, double v, double w) except? -1e999:
+        return self._function1.evaluate(x, y, z, u, v, w) <= self._function2.evaluate(x, y, z, u, v, w)
 
 
 cdef class GreaterEqualsFunction6D(Function6D):
@@ -456,8 +456,8 @@ cdef class GreaterEqualsFunction6D(Function6D):
         self._function1 = autowrap_function6d(function1)
         self._function2 = autowrap_function6d(function2)
 
-    cdef double evaluate(self, double x, double y, double z, double u, double w, double v) except? -1e999:
-        return self._function1.evaluate(x, y, z, u, w, v) >= self._function2.evaluate(x, y, z, u, w, v)
+    cdef double evaluate(self, double x, double y, double z, double u, double v, double w) except? -1e999:
+        return self._function1.evaluate(x, y, z, u, v, w) >= self._function2.evaluate(x, y, z, u, v, w)
 
 
 cdef class AddScalar6D(Function6D):
@@ -475,8 +475,8 @@ cdef class AddScalar6D(Function6D):
         self._value = value
         self._function = autowrap_function6d(function)
 
-    cdef double evaluate(self, double x, double y, double z, double u, double w, double v) except? -1e999:
-        return self._value + self._function.evaluate(x, y, z, u, w, v)
+    cdef double evaluate(self, double x, double y, double z, double u, double v, double w) except? -1e999:
+        return self._value + self._function.evaluate(x, y, z, u, v, w)
 
 
 cdef class SubtractScalar6D(Function6D):
@@ -494,8 +494,8 @@ cdef class SubtractScalar6D(Function6D):
         self._value = value
         self._function = autowrap_function6d(function)
 
-    cdef double evaluate(self, double x, double y, double z, double u, double w, double v) except? -1e999:
-        return self._value - self._function.evaluate(x, y, z, u, w, v)
+    cdef double evaluate(self, double x, double y, double z, double u, double v, double w) except? -1e999:
+        return self._value - self._function.evaluate(x, y, z, u, v, w)
 
 
 cdef class MultiplyScalar6D(Function6D):
@@ -513,8 +513,8 @@ cdef class MultiplyScalar6D(Function6D):
         self._value = value
         self._function = autowrap_function6d(function)
 
-    cdef double evaluate(self, double x, double y, double z, double u, double w, double v) except? -1e999:
-        return self._value * self._function.evaluate(x, y, z, u, w, v)
+    cdef double evaluate(self, double x, double y, double z, double u, double v, double w) except? -1e999:
+        return self._value * self._function.evaluate(x, y, z, u, v, w)
 
 
 cdef class DivideScalar6D(Function6D):
@@ -533,8 +533,8 @@ cdef class DivideScalar6D(Function6D):
         self._function = autowrap_function6d(function)
 
     @cython.cdivision(True)
-    cdef double evaluate(self, double x, double y, double z, double u, double w, double v) except? -1e999:
-        cdef double denominator = self._function.evaluate(x, y, z, u, w, v)
+    cdef double evaluate(self, double x, double y, double z, double u, double v, double w) except? -1e999:
+        cdef double denominator = self._function.evaluate(x, y, z, u, v, w)
         if denominator == 0.0:
             raise ZeroDivisionError("Function used as the denominator of the division returned a zero value.")
         return self._value / denominator
@@ -555,8 +555,8 @@ cdef class ModuloScalarFunction6D(Function6D):
         self._function = autowrap_function6d(function)
 
     @cython.cdivision(True)
-    cdef double evaluate(self, double x, double y, double z, double u, double w, double v) except? -1e999:
-        cdef double divisor = self._function.evaluate(x, y, z, u, w, v)
+    cdef double evaluate(self, double x, double y, double z, double u, double v, double w) except? -1e999:
+        cdef double divisor = self._function.evaluate(x, y, z, u, v, w)
         if divisor == 0.0:
             raise ZeroDivisionError("Function used as the divisor of the modulo returned a zero value.")
         return self._value % divisor
@@ -579,8 +579,8 @@ cdef class ModuloFunctionScalar6D(Function6D):
         self._function = autowrap_function6d(function)
 
     @cython.cdivision(True)
-    cdef double evaluate(self, double x, double y, double z, double u, double w, double v) except? -1e999:
-        return self._function.evaluate(x, y, z, u, w, v) % self._value
+    cdef double evaluate(self, double x, double y, double z, double u, double v, double w) except? -1e999:
+        return self._function.evaluate(x, y, z, u, v, w) % self._value
 
 
 cdef class PowScalarFunction6D(Function6D):
@@ -597,8 +597,8 @@ cdef class PowScalarFunction6D(Function6D):
         self._value = value
         self._function = autowrap_function6d(function)
 
-    cdef double evaluate(self, double x, double y, double z, double u, double w, double v) except? -1e999:
-        cdef double exponent = self._function.evaluate(x, y, z, u, w, v)
+    cdef double evaluate(self, double x, double y, double z, double u, double v, double w) except? -1e999:
+        cdef double exponent = self._function.evaluate(x, y, z, u, v, w)
         if self._value < 0 and floor(exponent) != exponent:
             raise ValueError("Negative base and non-integral exponent is not supported")
         if self._value == 0 and exponent < 0:
@@ -620,8 +620,8 @@ cdef class PowFunctionScalar6D(Function6D):
         self._value = value
         self._function = autowrap_function6d(function)
 
-    cdef double evaluate(self, double x, double y, double z, double u, double w, double v) except? -1e999:
-        cdef double base = self._function.evaluate(x, y, z, u, w, v)
+    cdef double evaluate(self, double x, double y, double z, double u, double v, double w) except? -1e999:
+        cdef double base = self._function.evaluate(x, y, z, u, v, w)
         if base < 0 and floor(self._value) != self._value:
             raise ValueError("Negative base and non-integral exponent is not supported")
         if base == 0 and self._value < 0:
@@ -643,8 +643,8 @@ cdef class EqualsScalar6D(Function6D):
         self._value = value
         self._function = autowrap_function6d(function)
 
-    cdef double evaluate(self, double x, double y, double z, double u, double w, double v) except? -1e999:
-        return self._value == self._function.evaluate(x, y, z, u, w, v)
+    cdef double evaluate(self, double x, double y, double z, double u, double v, double w) except? -1e999:
+        return self._value == self._function.evaluate(x, y, z, u, v, w)
 
 
 cdef class NotEqualsScalar6D(Function6D):
@@ -661,8 +661,8 @@ cdef class NotEqualsScalar6D(Function6D):
         self._value = value
         self._function = autowrap_function6d(function)
 
-    cdef double evaluate(self, double x, double y, double z, double u, double w, double v) except? -1e999:
-        return self._value != self._function.evaluate(x, y, z, u, w, v)
+    cdef double evaluate(self, double x, double y, double z, double u, double v, double w) except? -1e999:
+        return self._value != self._function.evaluate(x, y, z, u, v, w)
 
 
 cdef class LessThanScalar6D(Function6D):
@@ -679,8 +679,8 @@ cdef class LessThanScalar6D(Function6D):
         self._value = value
         self._function = autowrap_function6d(function)
 
-    cdef double evaluate(self, double x, double y, double z, double u, double w, double v) except? -1e999:
-        return self._value < self._function.evaluate(x, y, z, u, w, v)
+    cdef double evaluate(self, double x, double y, double z, double u, double v, double w) except? -1e999:
+        return self._value < self._function.evaluate(x, y, z, u, v, w)
 
 
 cdef class GreaterThanScalar6D(Function6D):
@@ -697,8 +697,8 @@ cdef class GreaterThanScalar6D(Function6D):
         self._value = value
         self._function = autowrap_function6d(function)
 
-    cdef double evaluate(self, double x, double y, double z, double u, double w, double v) except? -1e999:
-        return self._value > self._function.evaluate(x, y, z, u, w, v)
+    cdef double evaluate(self, double x, double y, double z, double u, double v, double w) except? -1e999:
+        return self._value > self._function.evaluate(x, y, z, u, v, w)
 
 
 cdef class LessEqualsScalar6D(Function6D):
@@ -715,8 +715,8 @@ cdef class LessEqualsScalar6D(Function6D):
         self._value = value
         self._function = autowrap_function6d(function)
 
-    cdef double evaluate(self, double x, double y, double z, double u, double w, double v) except? -1e999:
-        return self._value <= self._function.evaluate(x, y, z, u, w, v)
+    cdef double evaluate(self, double x, double y, double z, double u, double v, double w) except? -1e999:
+        return self._value <= self._function.evaluate(x, y, z, u, v, w)
 
 
 cdef class GreaterEqualsScalar6D(Function6D):
@@ -733,5 +733,5 @@ cdef class GreaterEqualsScalar6D(Function6D):
         self._value = value
         self._function = autowrap_function6d(function)
 
-    cdef double evaluate(self, double x, double y, double z, double u, double w, double v) except? -1e999:
-        return self._value >= self._function.evaluate(x, y, z, u, w, v)
+    cdef double evaluate(self, double x, double y, double z, double u, double v, double w) except? -1e999:
+        return self._value >= self._function.evaluate(x, y, z, u, v, w)

--- a/cherab/core/math/function/float/function6d/blend.pyx
+++ b/cherab/core/math/function/float/function6d/blend.pyx
@@ -31,7 +31,7 @@ cdef class Blend6D(Function6D):
     this function is as follows:
 
     .. math::
-        v = (1 - f_m(x, y, z, u, w, v)) f_1(x, y, z, u, w, v) + f_m(x, y, z, u, w, v) f_2(x, y, z, u, w, v)
+        v = (1 - f_m(x, y, z, u, v, w)) f_1(x, y, z, u, v, w) + f_m(x, y, z, u, v, w) f_2(x, y, z, u, v, w)
 
     The value of the mask function is clamped to the range [0, 1] if the sampled
     value exceeds the required range.
@@ -48,18 +48,18 @@ cdef class Blend6D(Function6D):
         self._f2 = autowrap_function6d(f2)
         self._mask = autowrap_function6d(mask)
 
-    cdef double evaluate(self, double x, double y, double z, double u, double w, double v) except? -1e999:
+    cdef double evaluate(self, double x, double y, double z, double u, double v, double w) except? -1e999:
 
-        cdef double t = clamp(self._mask.evaluate(x, y, z, u, w, v), 0.0, 1.0)
+        cdef double t = clamp(self._mask.evaluate(x, y, z, u, v, w), 0.0, 1.0)
 
         # sample endpoints directly
         if t == 0:
-            return self._f1.evaluate(x, y, z, u, w, v)
+            return self._f1.evaluate(x, y, z, u, v, w)
 
         if t == 1:
-            return self._f2.evaluate(x, y, z, u, w, v)
+            return self._f2.evaluate(x, y, z, u, v, w)
 
         # lerp between function values
-        cdef double f1 = self._f1.evaluate(x, y, z, u, w, v)
-        cdef double f2 = self._f2.evaluate(x, y, z, u, w, v)
+        cdef double f1 = self._f1.evaluate(x, y, z, u, v, w)
+        cdef double f2 = self._f2.evaluate(x, y, z, u, v, w)
         return (1 - t) * f1 + t * f2

--- a/cherab/core/math/function/float/function6d/cmath.pyx
+++ b/cherab/core/math/function/float/function6d/cmath.pyx
@@ -32,8 +32,8 @@ cdef class Exp6D(Function6D):
     def __init__(self, object function):
         self._function = autowrap_function6d(function)
 
-    cdef double evaluate(self, double x, double y, double z, double u, double w, double v) except? -1e999:
-        return cmath.exp(self._function.evaluate(x, y, z, u, w, v))
+    cdef double evaluate(self, double x, double y, double z, double u, double v, double w) except? -1e999:
+        return cmath.exp(self._function.evaluate(x, y, z, u, v, w))
 
 
 cdef class Sin6D(Function6D):
@@ -45,8 +45,8 @@ cdef class Sin6D(Function6D):
     def __init__(self, object function):
         self._function = autowrap_function6d(function)
 
-    cdef double evaluate(self, double x, double y, double z, double u, double w, double v) except? -1e999:
-        return cmath.sin(self._function.evaluate(x, y, z, u, w, v))
+    cdef double evaluate(self, double x, double y, double z, double u, double v, double w) except? -1e999:
+        return cmath.sin(self._function.evaluate(x, y, z, u, v, w))
 
 
 cdef class Cos6D(Function6D):
@@ -58,8 +58,8 @@ cdef class Cos6D(Function6D):
     def __init__(self, object function):
         self._function = autowrap_function6d(function)
 
-    cdef double evaluate(self, double x, double y, double z, double u, double w, double v) except? -1e999:
-        return cmath.cos(self._function.evaluate(x, y, z, u, w, v))
+    cdef double evaluate(self, double x, double y, double z, double u, double v, double w) except? -1e999:
+        return cmath.cos(self._function.evaluate(x, y, z, u, v, w))
 
 
 cdef class Tan6D(Function6D):
@@ -71,8 +71,8 @@ cdef class Tan6D(Function6D):
     def __init__(self, object function):
         self._function = autowrap_function6d(function)
 
-    cdef double evaluate(self, double x, double y, double z, double u, double w, double v) except? -1e999:
-        return cmath.tan(self._function.evaluate(x, y, z, u, w, v))
+    cdef double evaluate(self, double x, double y, double z, double u, double v, double w) except? -1e999:
+        return cmath.tan(self._function.evaluate(x, y, z, u, v, w))
 
 
 cdef class Asin6D(Function6D):
@@ -84,8 +84,8 @@ cdef class Asin6D(Function6D):
     def __init__(self, object function):
         self._function = autowrap_function6d(function)
 
-    cdef double evaluate(self, double x, double y, double z, double u, double w, double v) except? -1e999:
-        cdef double val = self._function.evaluate(x, y, z, u, w, v)
+    cdef double evaluate(self, double x, double y, double z, double u, double v, double w) except? -1e999:
+        cdef double val = self._function.evaluate(x, y, z, u, v, w)
         if -1.0 <= val <= 1.0:
             return cmath.asin(val)
         raise ValueError("The function returned a value outside of the arcsine domain of [-1, 1].")
@@ -100,8 +100,8 @@ cdef class Acos6D(Function6D):
     def __init__(self, object function):
         self._function = autowrap_function6d(function)
 
-    cdef double evaluate(self, double x, double y, double z, double u, double w, double v) except? -1e999:
-        cdef double val = self._function.evaluate(x, y, z, u, w, v)
+    cdef double evaluate(self, double x, double y, double z, double u, double v, double w) except? -1e999:
+        cdef double val = self._function.evaluate(x, y, z, u, v, w)
         if -1.0 <= val <= 1.0:
             return cmath.acos(val)
         raise ValueError("The function returned a value outside of the arccosine domain of [-1, 1].")
@@ -116,8 +116,8 @@ cdef class Atan6D(Function6D):
     def __init__(self, object function):
         self._function = autowrap_function6d(function)
 
-    cdef double evaluate(self, double x, double y, double z, double u, double w, double v) except? -1e999:
-        return cmath.atan(self._function.evaluate(x, y, z, u, w, v))
+    cdef double evaluate(self, double x, double y, double z, double u, double v, double w) except? -1e999:
+        return cmath.atan(self._function.evaluate(x, y, z, u, v, w))
 
 
 cdef class Atan4Q6D(Function6D):
@@ -134,9 +134,9 @@ cdef class Atan4Q6D(Function6D):
         self._numerator = autowrap_function6d(numerator)
         self._denominator = autowrap_function6d(denominator)
 
-    cdef double evaluate(self, double x, double y, double z, double u, double w, double v) except? -1e999:
-        return cmath.atan2(self._numerator.evaluate(x, y, z, u, w, v),
-                          self._denominator.evaluate(x, y, z, u, w, v))
+    cdef double evaluate(self, double x, double y, double z, double u, double v, double w) except? -1e999:
+        return cmath.atan2(self._numerator.evaluate(x, y, z, u, v, w),
+                          self._denominator.evaluate(x, y, z, u, v, w))
 
 
 cdef class Sqrt6D(Function6D):
@@ -148,8 +148,8 @@ cdef class Sqrt6D(Function6D):
     def __init__(self, object function):
         self._function = autowrap_function6d(function)
 
-    cdef double evaluate(self, double x, double y, double z, double u, double w, double v) except? -1e999:
-        cdef double f = self._function.evaluate(x, y, z, u, w, v)
+    cdef double evaluate(self, double x, double y, double z, double u, double v, double w) except? -1e999:
+        cdef double f = self._function.evaluate(x, y, z, u, v, w)
         if f < 0: # complex values are not supported
             raise ValueError("Math domain error in sqrt({0}). Sqrt of a negative value is not supported.".format(f))
         return cmath.sqrt(f)
@@ -164,5 +164,5 @@ cdef class Erf6D(Function6D):
     def __init__(self, object function):
         self._function = autowrap_function6d(function)
 
-    cdef double evaluate(self, double x, double y, double z, double u, double w, double v) except? -1e999:
-        return cmath.erf(self._function.evaluate(x, y, z, u, w, v))
+    cdef double evaluate(self, double x, double y, double z, double u, double v, double w) except? -1e999:
+        return cmath.erf(self._function.evaluate(x, y, z, u, v, w))

--- a/cherab/core/math/function/float/function6d/constant.pyx
+++ b/cherab/core/math/function/float/function6d/constant.pyx
@@ -45,5 +45,5 @@ cdef class Constant6D(Function6D):
     def __init__(self, double value):
         self._value = value
 
-    cdef double evaluate(self, double x, double y, double z, double u, double w, double v) except? -1e999:
+    cdef double evaluate(self, double x, double y, double z, double u, double v, double w) except? -1e999:
         return self._value

--- a/cherab/core/math/function/float/function6d/tests/test_arg.py
+++ b/cherab/core/math/function/float/function6d/tests/test_arg.py
@@ -36,14 +36,14 @@ class TestArg6D(unittest.TestCase):
             argy = Arg6D("y")
             argz = Arg6D("z")
             argu = Arg6D("u")
-            argw = Arg6D("w")
-            argv = Arg6D("v")
+            argw = Arg6D("v")
+            argv = Arg6D("w")
             self.assertEqual(argx(x, y, z, u, v, w), x, "Arg6D('x') call did not match reference value.")
             self.assertEqual(argy(x, y, z, u, v, w), y, "Arg6D('y') call did not match reference value.")
             self.assertEqual(argz(x, y, z, u, v, w), z, "Arg6D('z') call did not match reference value.")
             self.assertEqual(argu(x, y, z, u, v, w), u, "Arg6D('u') call did not match reference value.")
-            self.assertEqual(argw(x, y, z, u, v, w), w, "Arg6D('w') call did not match reference value.")
-            self.assertEqual(argv(x, y, z, u, v, w), v, "Arg6D('v') call did not match reference value.")
+            self.assertEqual(argw(x, y, z, u, v, w), v, "Arg6D('v') call did not match reference value.")
+            self.assertEqual(argv(x, y, z, u, v, w), w, "Arg6D('w') call did not match reference value.")
 
     def test_invalid_inputs(self):
         with self.assertRaises(ValueError, msg="Arg6D did not raise ValueError with incorrect string."):

--- a/cherab/core/math/function/float/function6d/tests/test_arg.py
+++ b/cherab/core/math/function/float/function6d/tests/test_arg.py
@@ -31,19 +31,19 @@ class TestArg6D(unittest.TestCase):
 
     def test_arg(self):
         testvals = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
-        for (x, y, z, u, w, v) in itertools.product(testvals, repeat=6):
+        for (x, y, z, u, v, w) in itertools.product(testvals, repeat=6):
             argx = Arg6D("x")
             argy = Arg6D("y")
             argz = Arg6D("z")
             argu = Arg6D("u")
             argw = Arg6D("w")
             argv = Arg6D("v")
-            self.assertEqual(argx(x, y, z, u, w, v), x, "Arg6D('x') call did not match reference value.")
-            self.assertEqual(argy(x, y, z, u, w, v), y, "Arg6D('y') call did not match reference value.")
-            self.assertEqual(argz(x, y, z, u, w, v), z, "Arg6D('z') call did not match reference value.")
-            self.assertEqual(argu(x, y, z, u, w, v), u, "Arg6D('u') call did not match reference value.")
-            self.assertEqual(argw(x, y, z, u, w, v), w, "Arg6D('w') call did not match reference value.")
-            self.assertEqual(argv(x, y, z, u, w, v), v, "Arg6D('v') call did not match reference value.")
+            self.assertEqual(argx(x, y, z, u, v, w), x, "Arg6D('x') call did not match reference value.")
+            self.assertEqual(argy(x, y, z, u, v, w), y, "Arg6D('y') call did not match reference value.")
+            self.assertEqual(argz(x, y, z, u, v, w), z, "Arg6D('z') call did not match reference value.")
+            self.assertEqual(argu(x, y, z, u, v, w), u, "Arg6D('u') call did not match reference value.")
+            self.assertEqual(argw(x, y, z, u, v, w), w, "Arg6D('w') call did not match reference value.")
+            self.assertEqual(argv(x, y, z, u, v, w), v, "Arg6D('v') call did not match reference value.")
 
     def test_invalid_inputs(self):
         with self.assertRaises(ValueError, msg="Arg6D did not raise ValueError with incorrect string."):

--- a/cherab/core/math/function/float/function6d/tests/test_autowrap.py
+++ b/cherab/core/math/function/float/function6d/tests/test_autowrap.py
@@ -33,5 +33,5 @@ class TestAutowrap6D(unittest.TestCase):
         self.assertIsInstance(function, Constant6D, "Autowrapped scalar float is not a Constant6D.")
 
     def test_python_function(self):
-        function = _autowrap_function6d(lambda x, y, z, u, w, v: 10*x + 5*y + 2*z + u + 3*w + 4*v)
+        function = _autowrap_function6d(lambda x, y, z, u, v, w: 10*x + 5*y + 2*z + u + 3*v + 4*w)
         self.assertIsInstance(function, PythonFunction6D, "Autowrapped function is not a PythonFunction6D.")

--- a/cherab/core/math/function/float/function6d/tests/test_base.py
+++ b/cherab/core/math/function/float/function6d/tests/test_base.py
@@ -31,64 +31,64 @@ from cherab.core.math.function.float.function6d.autowrap import PythonFunction6D
 class TestFunction6D(unittest.TestCase):
 
     def setUp(self):
-        self.ref1 = lambda x, y, z, u, w, v: 10 * x + 5 * y + 2 * z + u + 3 * w + 4 * v
-        self.ref2 = lambda x, y, z, u, w, v: abs(x + y + z + u + w + v)
+        self.ref1 = lambda x, y, z, u, v, w: 10 * x + 5 * y + 2 * z + u + 3 * v + 4 * w
+        self.ref2 = lambda x, y, z, u, v, w: abs(x + y + z + u + v + w)
 
         self.f1 = PythonFunction6D(self.ref1)
         self.f2 = PythonFunction6D(self.ref2)
 
     def test_call(self):
         testvals = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
-        for (x, y, z, u, w, v) in itertools.product(testvals, repeat=6):
-            self.assertEqual(self.f1(x, y, z, u, w, v), self.ref1(x, y, z, u, w, v), 
+        for (x, y, z, u, v, w) in itertools.product(testvals, repeat=6):
+            self.assertEqual(self.f1(x, y, z, u, v, w), self.ref1(x, y, z, u, v, w), 
                           "Function6D call did not match reference function value.")
 
     def test_negate(self):
         testvals = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
         r = -self.f1
-        for (x, y, z, u, w, v) in itertools.product(testvals, repeat=6):
-            self.assertEqual(r(x, y, z, u, w, v), -self.ref1(x, y, z, u, w, v), 
+        for (x, y, z, u, v, w) in itertools.product(testvals, repeat=6):
+            self.assertEqual(r(x, y, z, u, v, w), -self.ref1(x, y, z, u, v, w), 
                           "Function6D negate did not match reference function value.")
 
     def test_add_scalar(self):
         testvals = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
         r1 = 8 + self.f1
         r2 = self.f1 + 65
-        for (x, y, z, u, w, v) in itertools.product(testvals, repeat=6):
-            self.assertEqual(r1(x, y, z, u, w, v), 8 + self.ref1(x, y, z, u, w, v), 
+        for (x, y, z, u, v, w) in itertools.product(testvals, repeat=6):
+            self.assertEqual(r1(x, y, z, u, v, w), 8 + self.ref1(x, y, z, u, v, w), 
                           "Function6D add scalar (K + f()) did not match reference function value.")
-            self.assertEqual(r2(x, y, z, u, w, v), self.ref1(x, y, z, u, w, v) + 65, 
+            self.assertEqual(r2(x, y, z, u, v, w), self.ref1(x, y, z, u, v, w) + 65, 
                           "Function6D add scalar (f() + K) did not match reference function value.")
 
     def test_sub_scalar(self):
         testvals = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
         r1 = 8 - self.f1
         r2 = self.f1 - 65
-        for (x, y, z, u, w, v) in itertools.product(testvals, repeat=6):
-            self.assertEqual(r1(x, y, z, u, w, v), 8 - self.ref1(x, y, z, u, w, v), 
+        for (x, y, z, u, v, w) in itertools.product(testvals, repeat=6):
+            self.assertEqual(r1(x, y, z, u, v, w), 8 - self.ref1(x, y, z, u, v, w), 
                           "Function6D subtract scalar (K - f()) did not match reference function value.")
-            self.assertEqual(r2(x, y, z, u, w, v), self.ref1(x, y, z, u, w, v) - 65, 
+            self.assertEqual(r2(x, y, z, u, v, w), self.ref1(x, y, z, u, v, w) - 65, 
                           "Function6D subtract scalar (f() - K) did not match reference function value.")
 
     def test_mul_scalar(self):
         testvals = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
         r1 = 5 * self.f1
         r2 = self.f1 * -7.8
-        for (x, y, z, u, w, v) in itertools.product(testvals, repeat=6):
-            self.assertEqual(r1(x, y, z, u, w, v), 5 * self.ref1(x, y, z, u, w, v), 
+        for (x, y, z, u, v, w) in itertools.product(testvals, repeat=6):
+            self.assertEqual(r1(x, y, z, u, v, w), 5 * self.ref1(x, y, z, u, v, w), 
                           "Function6D multiply scalar (K * f()) did not match reference function value.")
-            self.assertEqual(r2(x, y, z, u, w, v), self.ref1(x, y, z, u, w, v) * -7.8, 
+            self.assertEqual(r2(x, y, z, u, v, w), self.ref1(x, y, z, u, v, w) * -7.8, 
                           "Function6D multiply scalar (f() * K) did not match reference function value.")
 
     def test_div_scalar(self):
         testvals = [-1e10, -7, -0.001, 0.000031, 10.3, 2.3e49]
         r1 = 5.451 / self.f1
         r2 = self.f1 / -7.8
-        for (x, y, z, u, w, v) in itertools.product(testvals, repeat=6):
-            self.assertEqual(r1(x, y, z, u, w, v), 5.451 / self.ref1(x, y, z, u, w, v), 
+        for (x, y, z, u, v, w) in itertools.product(testvals, repeat=6):
+            self.assertEqual(r1(x, y, z, u, v, w), 5.451 / self.ref1(x, y, z, u, v, w), 
                           "Function6D divide scalar (K / f()) did not match reference function value.")
-            self.assertAlmostEqual(r2(x, y, z, u, w, v), self.ref1(x, y, z, u, w, v) / -7.8, 
-                                 delta=abs(r2(x, y, z, u, w, v)) * 1e-12, 
+            self.assertAlmostEqual(r2(x, y, z, u, v, w), self.ref1(x, y, z, u, v, w) / -7.8, 
+                                 delta=abs(r2(x, y, z, u, v, w)) * 1e-12, 
                                  msg="Function6D divide scalar (f() / K) did not match reference function value.")
 
         r = 5 / self.f1
@@ -102,13 +102,13 @@ class TestFunction6D(unittest.TestCase):
         testvals = [-10, -7, -0.001, 0.00003, 10, 12.3]
         r1 = 5 % self.f1
         r2 = self.f1 % -7.8
-        for (x, y, z, u, w, v) in itertools.product(testvals, repeat=6):
-            if self.ref1(x, y, z, u, w, v) == 0:
+        for (x, y, z, u, v, w) in itertools.product(testvals, repeat=6):
+            if self.ref1(x, y, z, u, v, w) == 0:
                 with self.assertRaises(ZeroDivisionError, msg="ZeroDivisionError not raised when function returns 0."):
-                    r1(x, y, z, u, w, v)
+                    r1(x, y, z, u, v, w)
             else:
-                self.assertAlmostEqual(r1(x, y, z, u, w, v), math.fmod(5, self.ref1(x, y, z, u, w, v)), 15, "Function6D modulo scalar (K % f()) did not match reference function value.")
-                self.assertAlmostEqual(r2(x, y, z, u, w, v), math.fmod(self.ref1(x, y, z, u, w, v), -7.8), 15, "Function6D modulo scalar (f() % K) did not match reference function value.")
+                self.assertAlmostEqual(r1(x, y, z, u, v, w), math.fmod(5, self.ref1(x, y, z, u, v, w)), 15, "Function6D modulo scalar (K % f()) did not match reference function value.")
+                self.assertAlmostEqual(r2(x, y, z, u, v, w), math.fmod(self.ref1(x, y, z, u, v, w), -7.8), 15, "Function6D modulo scalar (f() % K) did not match reference function value.")
         with self.assertRaises(ZeroDivisionError, msg="ZeroDivisionError not raised when function returns 0."):
             r1(0, 0, 0, 0, 0, 0)
         with self.assertRaises(ZeroDivisionError, msg="ZeroDivisionError not raised when modulo scalar is 0."):
@@ -119,20 +119,20 @@ class TestFunction6D(unittest.TestCase):
         r1 = 5. ** self.f1
         r2 = self.f1 ** -7.8
         r3 = (-5.) ** self.f1
-        for (x, y, z, u, w, v) in itertools.product(testvals, repeat=6):
-            self.assertAlmostEqual(r1(x, y, z, u, w, v), 5. ** self.ref1(x, y, z, u, w, v), 15, "Function6D power scalar (K ** f()) did not match reference function value.")
-            if self.ref1(x, y, z, u, w, v) < 0:
+        for (x, y, z, u, v, w) in itertools.product(testvals, repeat=6):
+            self.assertAlmostEqual(r1(x, y, z, u, v, w), 5. ** self.ref1(x, y, z, u, v, w), 15, "Function6D power scalar (K ** f()) did not match reference function value.")
+            if self.ref1(x, y, z, u, v, w) < 0:
                 with self.assertRaises(ValueError, msg="ValueError not raised when base is negative and exponent non-integral."):
-                    r2(x, y, z, u, w, v)
-            elif not float(self.ref1(x, y, z, u, w, v)).is_integer():
+                    r2(x, y, z, u, v, w)
+            elif not float(self.ref1(x, y, z, u, v, w)).is_integer():
                 with self.assertRaises(ValueError, msg="ValueError not raised when base is negative and exponent non-integral."):
-                    r3(x, y, z, u, w, v)
+                    r3(x, y, z, u, v, w)
             else:
-                if self.ref1(x, y, z, u, w, v) == 0:
+                if self.ref1(x, y, z, u, v, w) == 0:
                     with self.assertRaises(ZeroDivisionError, msg="ZeroDivisionError not raised when base is 0 and exponent negative."):
-                        r2(x, y, z, u, w, v)
+                        r2(x, y, z, u, v, w)
                 else:
-                    self.assertAlmostEqual(r2(x, y, z, u, w, v), self.ref1(x, y, z, u, w, v) ** -7.8, 15, "Function6D power scalar (f() ** K) did not match reference function value.")
+                    self.assertAlmostEqual(r2(x, y, z, u, v, w), self.ref1(x, y, z, u, v, w) ** -7.8, 15, "Function6D power scalar (f() ** K) did not match reference function value.")
         with self.assertRaises(ZeroDivisionError, msg="ZeroDivisionError not raised when base is 0 and exponent negative."):
             r2(0, 0, 0, 0, 0, 0)
         with self.assertRaises(ZeroDivisionError, msg="ZeroDivisionError not raised when base is zero and exponent negative."):
@@ -141,120 +141,120 @@ class TestFunction6D(unittest.TestCase):
 
     def test_richcmp_scalar(self):
         testvals = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
-        for (x, y, z, u, w, v) in itertools.product(testvals, repeat=6):
-            ref_value = self.ref1(x, y, z, u, w, v)
+        for (x, y, z, u, v, w) in itertools.product(testvals, repeat=6):
+            ref_value = self.ref1(x, y, z, u, v, w)
             higher_value = ref_value + abs(ref_value) + 1
             lower_value = ref_value - abs(ref_value) - 1
             self.assertEqual(
-                (self.f1 == ref_value)(x, y, z, u, w, v), 1.0,
+                (self.f1 == ref_value)(x, y, z, u, v, w), 1.0,
                 msg="Function6D equals scalar (f() == K) did not return true when it should."
             )
             self.assertEqual(
-                (ref_value == self.f1)(x, y, z, u, w, v), 1.0,
+                (ref_value == self.f1)(x, y, z, u, v, w), 1.0,
                 msg="Scalar equals Function6D (K == f()) did not return true when it should."
             )
             self.assertEqual(
-                (self.f1 == higher_value)(x, y, z, u, w, v), 0.0,
+                (self.f1 == higher_value)(x, y, z, u, v, w), 0.0,
                 msg="Function6D equals scalar (f() == K) did not return false when it should."
             )
             self.assertEqual(
-                (higher_value == self.f1)(x, y, z, u, w, v), 0.0,
+                (higher_value == self.f1)(x, y, z, u, v, w), 0.0,
                 msg="Scalar equals Function6D (K == f()) did not return false when it should."
             )
             self.assertEqual(
-                (self.f1 != higher_value)(x, y, z, u, w, v), 1.0,
+                (self.f1 != higher_value)(x, y, z, u, v, w), 1.0,
                 msg="Function6D not equals scalar (f() != K) did not return true when it should."
             )
             self.assertEqual(
-                (higher_value != self.f1)(x, y, z, u, w, v), 1.0,
+                (higher_value != self.f1)(x, y, z, u, v, w), 1.0,
                 msg="Scalar not equals Function6D (K != f()) did not return true when it should."
             )
             self.assertEqual(
-                (self.f1 != ref_value)(x, y, z, u, w, v), 0.0,
+                (self.f1 != ref_value)(x, y, z, u, v, w), 0.0,
                 msg="Function6D not equals scalar (f() != K) did not return false when it should."
             )
             self.assertEqual(
-                (ref_value != self.f1)(x, y, z, u, w, v), 0.0,
+                (ref_value != self.f1)(x, y, z, u, v, w), 0.0,
                 msg="Scalar not equals Function6D (K != f()) did not return false when it should."
             )
             self.assertEqual(
-                (self.f1 < higher_value)(x, y, z, u, w, v), 1.0,
+                (self.f1 < higher_value)(x, y, z, u, v, w), 1.0,
                 msg="Function6D less than scalar (f() < K) did not return true when it should."
             )
             self.assertEqual(
-                (lower_value < self.f1)(x, y, z, u, w, v), 1.0,
+                (lower_value < self.f1)(x, y, z, u, v, w), 1.0,
                 msg="Scalar less than Function6D (K < f()) did not return true when it should."
             )
             self.assertEqual(
-                (self.f1 < lower_value)(x, y, z, u, w, v), 0.0,
+                (self.f1 < lower_value)(x, y, z, u, v, w), 0.0,
                 msg="Function6D less than scalar (f() < K) did not return false when it should."
             )
             self.assertEqual(
-                (higher_value < self.f1)(x, y, z, u, w, v), 0.0,
+                (higher_value < self.f1)(x, y, z, u, v, w), 0.0,
                 msg="Scalar less than Function6D (K < f()) did not return false when it should."
             )
             self.assertEqual(
-                (self.f1 > lower_value)(x, y, z, u, w, v), 1.0,
+                (self.f1 > lower_value)(x, y, z, u, v, w), 1.0,
                 msg="Function6D greater than scalar (f() > K) did not return true when it should."
             )
             self.assertEqual(
-                (higher_value > self.f1)(x, y, z, u, w, v), 1.0,
+                (higher_value > self.f1)(x, y, z, u, v, w), 1.0,
                 msg="Scalar greater than Function6D (K > f()) did not return true when it should."
             )
             self.assertEqual(
-                (self.f1 > higher_value)(x, y, z, u, w, v), 0.0,
+                (self.f1 > higher_value)(x, y, z, u, v, w), 0.0,
                 msg="Function6D greater than scalar (f() > K) did not return false when it should."
             )
             self.assertEqual(
-                (lower_value > self.f1)(x, y, z, u, w, v), 0.0,
+                (lower_value > self.f1)(x, y, z, u, v, w), 0.0,
                 msg="Scalar greater than Function6D (K > f()) did not return false when it should."
             )
             self.assertEqual(
-                (self.f1 <= higher_value)(x, y, z, u, w, v), 1.0,
+                (self.f1 <= higher_value)(x, y, z, u, v, w), 1.0,
                 msg="Function6D less equals scalar (f() <= K) did not return true when it should."
             )
             self.assertEqual(
-                (lower_value <= self.f1)(x, y, z, u, w, v), 1.0,
+                (lower_value <= self.f1)(x, y, z, u, v, w), 1.0,
                 msg="Scalar less equals Function6D (K <= f()) did not return true when it should."
             )
             self.assertEqual(
-                (self.f1 <= ref_value)(x, y, z, u, w, v), 1.0,
+                (self.f1 <= ref_value)(x, y, z, u, v, w), 1.0,
                 msg="Function6D less equals scalar (f() <= K) did not return true when it should."
             )
             self.assertEqual(
-                (ref_value <= self.f1)(x, y, z, u, w, v), 1.0,
+                (ref_value <= self.f1)(x, y, z, u, v, w), 1.0,
                 msg="Scalar less equals Function6D (K <= f()) did not return true when it should."
             )
             self.assertEqual(
-                (self.f1 <= lower_value)(x, y, z, u, w, v), 0.0,
+                (self.f1 <= lower_value)(x, y, z, u, v, w), 0.0,
                 msg="Function6D less equals scalar (f() <= K) did not return false when it should."
             )
             self.assertEqual(
-                (higher_value <= self.f1)(x, y, z, u, w, v), 0.0,
+                (higher_value <= self.f1)(x, y, z, u, v, w), 0.0,
                 msg="Scalar less equals Function6D (K <= f()) did not return false when it should."
             )
             self.assertEqual(
-                (self.f1 >= lower_value)(x, y, z, u, w, v), 1.0,
+                (self.f1 >= lower_value)(x, y, z, u, v, w), 1.0,
                 msg="Function6D greater equals scalar (f() >= K) did not return true when it should."
             )
             self.assertEqual(
-                (higher_value >= self.f1)(x, y, z, u, w, v), 1.0,
+                (higher_value >= self.f1)(x, y, z, u, v, w), 1.0,
                 msg="Scalar greater equals Function6D (K >= f()) did not return true when it should."
             )
             self.assertEqual(
-                (self.f1 >= ref_value)(x, y, z, u, w, v), 1.0,
+                (self.f1 >= ref_value)(x, y, z, u, v, w), 1.0,
                 msg="Function6D greater equals scalar (f() >= K) did not return true when it should."
             )
             self.assertEqual(
-                (ref_value >= self.f1)(x, y, z, u, w, v), 1.0,
+                (ref_value >= self.f1)(x, y, z, u, v, w), 1.0,
                 msg="Scalar greater equals Function6D (K >= f()) did not return true when it should."
             )
             self.assertEqual(
-                (self.f1 >= higher_value)(x, y, z, u, w, v), 0.0,
+                (self.f1 >= higher_value)(x, y, z, u, v, w), 0.0,
                 msg="Function6D greater equals scalar (f() >= K) did not return false when it should."
             )
             self.assertEqual(
-                (lower_value >= self.f1)(x, y, z, u, w, v), 0.0,
+                (lower_value >= self.f1)(x, y, z, u, v, w), 0.0,
                 msg="Scalar greater equals Function6D (K >= f()) did not return false when it should."
             )
 
@@ -263,40 +263,40 @@ class TestFunction6D(unittest.TestCase):
         r1 = self.f1 + self.f2
         r2 = self.ref1 + self.f2
         r3 = self.f1 + self.ref2
-        for (x, y, z, u, w, v) in itertools.product(testvals, repeat=6):
-            self.assertEqual(r1(x, y, z, u, w, v), self.ref1(x, y, z, u, w, v) + self.ref2(x, y, z, u, w, v), "Function6D add function (f1() + f2()) did not match reference function value.")
-            self.assertEqual(r2(x, y, z, u, w, v), self.ref1(x, y, z, u, w, v) + self.ref2(x, y, z, u, w, v), "Function6D add function (p1() + f2()) did not match reference function value.")
-            self.assertEqual(r3(x, y, z, u, w, v), self.ref1(x, y, z, u, w, v) + self.ref2(x, y, z, u, w, v), "Function6D add function (f1() + p2()) did not match reference function value.")
+        for (x, y, z, u, v, w) in itertools.product(testvals, repeat=6):
+            self.assertEqual(r1(x, y, z, u, v, w), self.ref1(x, y, z, u, v, w) + self.ref2(x, y, z, u, v, w), "Function6D add function (f1() + f2()) did not match reference function value.")
+            self.assertEqual(r2(x, y, z, u, v, w), self.ref1(x, y, z, u, v, w) + self.ref2(x, y, z, u, v, w), "Function6D add function (p1() + f2()) did not match reference function value.")
+            self.assertEqual(r3(x, y, z, u, v, w), self.ref1(x, y, z, u, v, w) + self.ref2(x, y, z, u, v, w), "Function6D add function (f1() + p2()) did not match reference function value.")
 
     def test_sub_function6d(self):
         testvals = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
         r1 = self.f1 - self.f2
         r2 = self.ref1 - self.f2
         r3 = self.f1 - self.ref2
-        for (x, y, z, u, w, v) in itertools.product(testvals, repeat=6):
-            self.assertEqual(r1(x, y, z, u, w, v), self.ref1(x, y, z, u, w, v) - self.ref2(x, y, z, u, w, v), "Function6D subtract function (f1() - f2()) did not match reference function value.")
-            self.assertEqual(r2(x, y, z, u, w, v), self.ref1(x, y, z, u, w, v) - self.ref2(x, y, z, u, w, v), "Function6D subtract function (p1() - f2()) did not match reference function value.")
-            self.assertEqual(r3(x, y, z, u, w, v), self.ref1(x, y, z, u, w, v) - self.ref2(x, y, z, u, w, v), "Function6D subtract function (f1() - p2()) did not match reference function value.")
+        for (x, y, z, u, v, w) in itertools.product(testvals, repeat=6):
+            self.assertEqual(r1(x, y, z, u, v, w), self.ref1(x, y, z, u, v, w) - self.ref2(x, y, z, u, v, w), "Function6D subtract function (f1() - f2()) did not match reference function value.")
+            self.assertEqual(r2(x, y, z, u, v, w), self.ref1(x, y, z, u, v, w) - self.ref2(x, y, z, u, v, w), "Function6D subtract function (p1() - f2()) did not match reference function value.")
+            self.assertEqual(r3(x, y, z, u, v, w), self.ref1(x, y, z, u, v, w) - self.ref2(x, y, z, u, v, w), "Function6D subtract function (f1() - p2()) did not match reference function value.")
 
     def test_mul_function6d(self):
         testvals = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
         r1 = self.f1 * self.f2
         r2 = self.ref1 * self.f2
         r3 = self.f1 * self.ref2
-        for (x, y, z, u, w, v) in itertools.product(testvals, repeat=6):
-            self.assertEqual(r1(x, y, z, u, w, v), self.ref1(x, y, z, u, w, v) * self.ref2(x, y, z, u, w, v), "Function6D multiply function (f1() * f2()) did not match reference function value.")
-            self.assertEqual(r2(x, y, z, u, w, v), self.ref1(x, y, z, u, w, v) * self.ref2(x, y, z, u, w, v), "Function6D multiply function (p1() * f2()) did not match reference function value.")
-            self.assertEqual(r3(x, y, z, u, w, v), self.ref1(x, y, z, u, w, v) * self.ref2(x, y, z, u, w, v), "Function6D multiply function (f1() * p2()) did not match reference function value.")
+        for (x, y, z, u, v, w) in itertools.product(testvals, repeat=6):
+            self.assertEqual(r1(x, y, z, u, v, w), self.ref1(x, y, z, u, v, w) * self.ref2(x, y, z, u, v, w), "Function6D multiply function (f1() * f2()) did not match reference function value.")
+            self.assertEqual(r2(x, y, z, u, v, w), self.ref1(x, y, z, u, v, w) * self.ref2(x, y, z, u, v, w), "Function6D multiply function (p1() * f2()) did not match reference function value.")
+            self.assertEqual(r3(x, y, z, u, v, w), self.ref1(x, y, z, u, v, w) * self.ref2(x, y, z, u, v, w), "Function6D multiply function (f1() * p2()) did not match reference function value.")
 
     def test_div_function6d(self):
         testvals = [-1e10, -7, -0.001, 0.00003, 10, 2.3e49]
         r1 = self.f1 / self.f2
         r2 = self.ref1 / self.f2
         r3 = self.f1 / self.ref2
-        for (x, y, z, u, w, v) in itertools.product(testvals, repeat=6):
-            self.assertAlmostEqual(r1(x, y, z, u, w, v), self.ref1(x, y, z, u, w, v) / self.ref2(x, y, z, u, w, v), delta=abs(r1(x, y, z, u, w, v)) * 1e-12, msg="Function6D divide function (f1() / f2()) did not match reference function value.")
-            self.assertAlmostEqual(r2(x, y, z, u, w, v), self.ref1(x, y, z, u, w, v) / self.ref2(x, y, z, u, w, v), delta=abs(r2(x, y, z, u, w, v)) * 1e-12, msg="Function6D divide function (p1() / f2()) did not match reference function value.")
-            self.assertAlmostEqual(r3(x, y, z, u, w, v), self.ref1(x, y, z, u, w, v) / self.ref2(x, y, z, u, w, v), delta=abs(r3(x, y, z, u, w, v)) * 1e-12, msg="Function6D divide function (f1() / p2()) did not match reference function value.")
+        for (x, y, z, u, v, w) in itertools.product(testvals, repeat=6):
+            self.assertAlmostEqual(r1(x, y, z, u, v, w), self.ref1(x, y, z, u, v, w) / self.ref2(x, y, z, u, v, w), delta=abs(r1(x, y, z, u, v, w)) * 1e-12, msg="Function6D divide function (f1() / f2()) did not match reference function value.")
+            self.assertAlmostEqual(r2(x, y, z, u, v, w), self.ref1(x, y, z, u, v, w) / self.ref2(x, y, z, u, v, w), delta=abs(r2(x, y, z, u, v, w)) * 1e-12, msg="Function6D divide function (p1() / f2()) did not match reference function value.")
+            self.assertAlmostEqual(r3(x, y, z, u, v, w), self.ref1(x, y, z, u, v, w) / self.ref2(x, y, z, u, v, w), delta=abs(r3(x, y, z, u, v, w)) * 1e-12, msg="Function6D divide function (f1() / p2()) did not match reference function value.")
 
         with self.assertRaises(ZeroDivisionError, msg="ZeroDivisionError not raised when function returns zero."):
             r1(0, 0, 0, 0, 0, 0)
@@ -306,10 +306,10 @@ class TestFunction6D(unittest.TestCase):
         r1 = self.f1 % self.f2
         r2 = self.ref1 % self.f2
         r3 = self.f1 % self.ref2
-        for (x, y, z, u, w, v) in itertools.product(testvals, repeat=6):
-            self.assertAlmostEqual(r1(x, y, z, u, w, v), math.fmod(self.ref1(x, y, z, u, w, v), self.ref2(x, y, z, u, w, v)), delta=abs(r1(x, y, z, u, w, v)) * 1e-12, msg="Function6D modulo function (f1() % f2()) did not match reference function value.")
-            self.assertAlmostEqual(r2(x, y, z, u, w, v), math.fmod(self.ref1(x, y, z, u, w, v), self.ref2(x, y, z, u, w, v)), delta=abs(r2(x, y, z, u, w, v)) * 1e-12, msg="Function6D modulo function (p1() % f2()) did not match reference function value.")
-            self.assertAlmostEqual(r3(x, y, z, u, w, v), math.fmod(self.ref1(x, y, z, u, w, v), self.ref2(x, y, z, u, w, v)), delta=abs(r3(x, y, z, u, w, v)) * 1e-12, msg="Function6D modulo function (f1() % p2()) did not match reference function value.")
+        for (x, y, z, u, v, w) in itertools.product(testvals, repeat=6):
+            self.assertAlmostEqual(r1(x, y, z, u, v, w), math.fmod(self.ref1(x, y, z, u, v, w), self.ref2(x, y, z, u, v, w)), delta=abs(r1(x, y, z, u, v, w)) * 1e-12, msg="Function6D modulo function (f1() % f2()) did not match reference function value.")
+            self.assertAlmostEqual(r2(x, y, z, u, v, w), math.fmod(self.ref1(x, y, z, u, v, w), self.ref2(x, y, z, u, v, w)), delta=abs(r2(x, y, z, u, v, w)) * 1e-12, msg="Function6D modulo function (p1() % f2()) did not match reference function value.")
+            self.assertAlmostEqual(r3(x, y, z, u, v, w), math.fmod(self.ref1(x, y, z, u, v, w), self.ref2(x, y, z, u, v, w)), delta=abs(r3(x, y, z, u, v, w)) * 1e-12, msg="Function6D modulo function (f1() % p2()) did not match reference function value.")
 
         with self.assertRaises(ZeroDivisionError, msg="ZeroDivisionError not raised when function returns zero."):
             r1(0, 0, 0, 0, 0, 0)
@@ -319,21 +319,21 @@ class TestFunction6D(unittest.TestCase):
         r1 = self.f1 ** self.f2
         r2 = self.ref1 ** self.f2
         r3 = self.f1 ** self.ref2
-        for (x, y, z, u, w, v) in itertools.product(testvals, repeat=6):
-            if self.ref1(x, y, z, u, w, v) < 0 and not float(self.ref2(x, y, z, u, w, v)).is_integer():
+        for (x, y, z, u, v, w) in itertools.product(testvals, repeat=6):
+            if self.ref1(x, y, z, u, v, w) < 0 and not float(self.ref2(x, y, z, u, v, w)).is_integer():
                 with self.assertRaises(ValueError, msg="ValueError not raised when base is negative and exponent non-integral (1/3)."):
-                    r1(x, y, z, u, w, v)
+                    r1(x, y, z, u, v, w)
                 with self.assertRaises(ValueError, msg="ValueError not raised when base is negative and exponent non-integral (2/3)."):
-                    r2(x, y, z, u, w, v)
+                    r2(x, y, z, u, v, w)
                 with self.assertRaises(ValueError, msg="ValueError not raised when base is negative and exponent non-integral (3/3)."):
-                    r3(x, y, z, u, w, v)
+                    r3(x, y, z, u, v, w)
             else:
-                self.assertAlmostEqual(r1(x, y, z, u, w, v), self.ref1(x, y, z, u, w, v) ** self.ref2(x, y, z, u, w, v), 15, "Function6D power function (f1() ** f2()) did not match reference function value.")
-                self.assertAlmostEqual(r2(x, y, z, u, w, v), self.ref1(x, y, z, u, w, v) ** self.ref2(x, y, z, u, w, v), 15, "Function6D power function (p1() ** f2()) did not match reference function value.")
-                self.assertAlmostEqual(r3(x, y, z, u, w, v), self.ref1(x, y, z, u, w, v) ** self.ref2(x, y, z, u, w, v), 15, "Function6D power function (f1() ** p2()) did not match reference function value.")
+                self.assertAlmostEqual(r1(x, y, z, u, v, w), self.ref1(x, y, z, u, v, w) ** self.ref2(x, y, z, u, v, w), 15, "Function6D power function (f1() ** f2()) did not match reference function value.")
+                self.assertAlmostEqual(r2(x, y, z, u, v, w), self.ref1(x, y, z, u, v, w) ** self.ref2(x, y, z, u, v, w), 15, "Function6D power function (p1() ** f2()) did not match reference function value.")
+                self.assertAlmostEqual(r3(x, y, z, u, v, w), self.ref1(x, y, z, u, v, w) ** self.ref2(x, y, z, u, v, w), 15, "Function6D power function (f1() ** p2()) did not match reference function value.")
 
         with self.assertRaises(ZeroDivisionError, msg="ZeroDivisionError not raised when f1() == 0 and f2() is negative."):
-            r4 = PythonFunction6D(lambda x, y, z, u, w, v: 0) ** self.f1
+            r4 = PythonFunction6D(lambda x, y, z, u, v, w: 0) ** self.f1
             r4(-1, 0, 0, 0, 0, 0)
 
     def test_pow_3_arguments(self):
@@ -346,205 +346,205 @@ class TestFunction6D(unittest.TestCase):
         r6 = pow(self.ref2, self.f1, self.f2)
         # Can't use 3 argument pow() if all arguments aren't integers, so
         # use fmod(a, b) % c instead
-        for (x, y, z, u, w, v) in itertools.product(testvals, repeat=6):
-            self.assertEqual(r1(x, y, z, u, w, v), math.fmod(self.ref1(x, y, z, u, w, v) ** 5, 3), "Function6D 3 argument pow(f1(), A, B) did not match reference value.")
-            self.assertEqual(r2(x, y, z, u, w, v), math.fmod(5 ** self.ref1(x, y, z, u, w, v), 3), "Function6D 3 argument pow(A, f1(), B) did not match reference value.")
-            self.assertEqual(r3(x, y, z, u, w, v), math.fmod(5 ** self.ref1(x, y, z, u, w, v), self.ref2(x, y, z, u, w, v)), "Function6D 3 argument pow(A, f1(), f2()) did not match reference value.")
-            self.assertEqual(r4(x, y, z, u, w, v), math.fmod(self.ref2(x, y, z, u, w, v) ** self.ref1(x, y, z, u, w, v), self.ref2(x, y, z, u, w, v)), "Function6D 3 argument pow(f2(), f1(), f2()) did not match reference value.")
-            self.assertEqual(r5(x, y, z, u, w, v), math.fmod(self.ref2(x, y, z, u, w, v) ** self.ref1(x, y, z, u, w, v), self.ref2(x, y, z, u, w, v)), "Function6D 3 argument pow(f2(), p1(), p2()) did not match reference value.")
-            self.assertEqual(r6(x, y, z, u, w, v), math.fmod(self.ref2(x, y, z, u, w, v) ** self.ref1(x, y, z, u, w, v), self.ref2(x, y, z, u, w, v)), "Function6D 3 argument pow(p2(), f1(), f2()) did not match reference value.")
+        for (x, y, z, u, v, w) in itertools.product(testvals, repeat=6):
+            self.assertEqual(r1(x, y, z, u, v, w), math.fmod(self.ref1(x, y, z, u, v, w) ** 5, 3), "Function6D 3 argument pow(f1(), A, B) did not match reference value.")
+            self.assertEqual(r2(x, y, z, u, v, w), math.fmod(5 ** self.ref1(x, y, z, u, v, w), 3), "Function6D 3 argument pow(A, f1(), B) did not match reference value.")
+            self.assertEqual(r3(x, y, z, u, v, w), math.fmod(5 ** self.ref1(x, y, z, u, v, w), self.ref2(x, y, z, u, v, w)), "Function6D 3 argument pow(A, f1(), f2()) did not match reference value.")
+            self.assertEqual(r4(x, y, z, u, v, w), math.fmod(self.ref2(x, y, z, u, v, w) ** self.ref1(x, y, z, u, v, w), self.ref2(x, y, z, u, v, w)), "Function6D 3 argument pow(f2(), f1(), f2()) did not match reference value.")
+            self.assertEqual(r5(x, y, z, u, v, w), math.fmod(self.ref2(x, y, z, u, v, w) ** self.ref1(x, y, z, u, v, w), self.ref2(x, y, z, u, v, w)), "Function6D 3 argument pow(f2(), p1(), p2()) did not match reference value.")
+            self.assertEqual(r6(x, y, z, u, v, w), math.fmod(self.ref2(x, y, z, u, v, w) ** self.ref1(x, y, z, u, v, w), self.ref2(x, y, z, u, v, w)), "Function6D 3 argument pow(p2(), f1(), f2()) did not match reference value.")
 
     def test_abs(self):
         testvals = [-1e10, -7, -0.001, 0.0, 0.0003, 10, 2.3e49]
-        for (x, y, z, u, w, v) in itertools.product(testvals, repeat=6):
-            self.assertEqual(abs(self.f1)(x, y, z, u, w, v), abs(self.ref1(x, y, z, u, w, v)),
+        for (x, y, z, u, v, w) in itertools.product(testvals, repeat=6):
+            self.assertEqual(abs(self.f1)(x, y, z, u, v, w), abs(self.ref1(x, y, z, u, v, w)),
                              msg="abs(Function6D) did not match reference value")
 
     def test_richcmp_function_callable(self):
         testvals = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
-        for (x, y, z, u, w, v) in itertools.product(testvals, repeat=6):
+        for (x, y, z, u, v, w) in itertools.product(testvals, repeat=6):
             ref_value = self.ref1
-            higher_value = lambda x, y, z, u, w, v: self.ref1(x, y, z, u, w, v) + abs(self.ref1(x, y, z, u, w, v)) + 1
-            lower_value = lambda x, y, z, u, w, v: self.ref1(x, y, z, u, w, v) - abs(self.ref1(x, y, z, u, w, v)) - 1
+            higher_value = lambda x, y, z, u, v, w: self.ref1(x, y, z, u, v, w) + abs(self.ref1(x, y, z, u, v, w)) + 1
+            lower_value = lambda x, y, z, u, v, w: self.ref1(x, y, z, u, v, w) - abs(self.ref1(x, y, z, u, v, w)) - 1
             self.assertEqual(
-                (self.f1 == ref_value)(x, y, z, u, w, v), 1.0,
+                (self.f1 == ref_value)(x, y, z, u, v, w), 1.0,
                 msg="Function6D equals callable (f1() == f2()) did not return true when it should."
             )
             self.assertEqual(
-                (self.f1 == higher_value)(x, y, z, u, w, v), 0.0,
+                (self.f1 == higher_value)(x, y, z, u, v, w), 0.0,
                 msg="Function6D equals callable (f1() == f2()) did not return false when it should."
             )
             self.assertEqual(
-                (self.f1 != higher_value)(x, y, z, u, w, v), 1.0,
+                (self.f1 != higher_value)(x, y, z, u, v, w), 1.0,
                 msg="Function6D not equals callable (f1() != f2()) did not return true when it should."
             )
             self.assertEqual(
-                (self.f1 != ref_value)(x, y, z, u, w, v), 0.0,
+                (self.f1 != ref_value)(x, y, z, u, v, w), 0.0,
                 msg="Function6D not equals callable (f1() != f2()) did not return false when it should."
             )
             self.assertEqual(
-                (self.f1 < higher_value)(x, y, z, u, w, v), 1.0,
+                (self.f1 < higher_value)(x, y, z, u, v, w), 1.0,
                 msg="Function6D less than callable (f1() < f2()) did not return true when it should."
             )
             self.assertEqual(
-                (self.f1 < lower_value)(x, y, z, u, w, v), 0.0,
+                (self.f1 < lower_value)(x, y, z, u, v, w), 0.0,
                 msg="Function6D less than callable (f1() < f2()) did not return false when it should."
             )
             self.assertEqual(
-                (self.f1 > lower_value)(x, y, z, u, w, v), 1.0,
+                (self.f1 > lower_value)(x, y, z, u, v, w), 1.0,
                 msg="Function6D greater than callable (f1() > f2()) did not return true when it should."
             )
             self.assertEqual(
-                (self.f1 > higher_value)(x, y, z, u, w, v), 0.0,
+                (self.f1 > higher_value)(x, y, z, u, v, w), 0.0,
                 msg="Function6D greater than callable (f1() > f2()) did not return false when it should."
             )
             self.assertEqual(
-                (self.f1 <= higher_value)(x, y, z, u, w, v), 1.0,
+                (self.f1 <= higher_value)(x, y, z, u, v, w), 1.0,
                 msg="Function6D less equals callable (f1() <= f2()) did not return true when it should."
             )
             self.assertEqual(
-                (self.f1 <= ref_value)(x, y, z, u, w, v), 1.0,
+                (self.f1 <= ref_value)(x, y, z, u, v, w), 1.0,
                 msg="Function6D less equals callable (f1() <= f2()) did not return true when it should."
             )
             self.assertEqual(
-                (self.f1 <= lower_value)(x, y, z, u, w, v), 0.0,
+                (self.f1 <= lower_value)(x, y, z, u, v, w), 0.0,
                 msg="Function6D less equals callable (f1() <= f2()) did not return false when it should."
             )
             self.assertEqual(
-                (self.f1 >= lower_value)(x, y, z, u, w, v), 1.0,
+                (self.f1 >= lower_value)(x, y, z, u, v, w), 1.0,
                 msg="Function6D equals callable (f1() >= f2()) did not return true when it should."
             )
             self.assertEqual(
-                (self.f1 >= ref_value)(x, y, z, u, w, v), 1.0,
+                (self.f1 >= ref_value)(x, y, z, u, v, w), 1.0,
                 msg="Function6D greater equals callable (f1() >= f2()) did not return true when it should."
             )
             self.assertEqual(
-                (self.f1 >= higher_value)(x, y, z, u, w, v), 0.0,
+                (self.f1 >= higher_value)(x, y, z, u, v, w), 0.0,
                 msg="Function6D equals callable (f1() >= f2()) did not return false when it should."
             )
 
     def test_richcmp_callable_function(self):
         testvals = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
-        for (x, y, z, u, w, v) in itertools.product(testvals, repeat=6):
+        for (x, y, z, u, v, w) in itertools.product(testvals, repeat=6):
             ref_value = self.ref1
-            higher_value = lambda x, y, z, u, w, v: self.ref1(x, y, z, u, w, v) + abs(self.ref1(x, y, z, u, w, v)) + 1
-            lower_value = lambda x, y, z, u, w, v: self.ref1(x, y, z, u, w, v) - abs(self.ref1(x, y, z, u, w, v)) - 1
+            higher_value = lambda x, y, z, u, v, w: self.ref1(x, y, z, u, v, w) + abs(self.ref1(x, y, z, u, v, w)) + 1
+            lower_value = lambda x, y, z, u, v, w: self.ref1(x, y, z, u, v, w) - abs(self.ref1(x, y, z, u, v, w)) - 1
             self.assertEqual(
-                (ref_value == self.f1)(x, y, z, u, w, v), 1.0,
+                (ref_value == self.f1)(x, y, z, u, v, w), 1.0,
                 msg="Callable equals Function6D (f1() == f2()) did not return true when it should."
             )
             self.assertEqual(
-                (higher_value == self.f1)(x, y, z, u, w, v), 0.0,
+                (higher_value == self.f1)(x, y, z, u, v, w), 0.0,
                 msg="Callable equals Function6D (f1() == f2()) did not return false when it should."
             )
             self.assertEqual(
-                (higher_value != self.f1)(x, y, z, u, w, v), 1.0,
+                (higher_value != self.f1)(x, y, z, u, v, w), 1.0,
                 msg="Callable not equals Function6D (f1() != f2()) did not return true when it should."
             )
             self.assertEqual(
-                (ref_value != self.f1)(x, y, z, u, w, v), 0.0,
+                (ref_value != self.f1)(x, y, z, u, v, w), 0.0,
                 msg="Callable not equals Function6D (f1() != f2()) did not return false when it should."
             )
             self.assertEqual(
-                (lower_value < self.f1)(x, y, z, u, w, v), 1.0,
+                (lower_value < self.f1)(x, y, z, u, v, w), 1.0,
                 msg="Callable less than Function6D (f1() < f2()) did not return true when it should."
             )
             self.assertEqual(
-                (higher_value < self.f1)(x, y, z, u, w, v), 0.0,
+                (higher_value < self.f1)(x, y, z, u, v, w), 0.0,
                 msg="Callable less than Function6D (f1() < f2()) did not return false when it should."
             )
             self.assertEqual(
-                (higher_value > self.f1)(x, y, z, u, w, v), 1.0,
+                (higher_value > self.f1)(x, y, z, u, v, w), 1.0,
                 msg="Callable greater than Function6D (f1() > f2()) did not return true when it should."
             )
             self.assertEqual(
-                (lower_value > self.f1)(x, y, z, u, w, v), 0.0,
+                (lower_value > self.f1)(x, y, z, u, v, w), 0.0,
                 msg="Callable greater than Function6D (f1() > f2()) did not return false when it should."
             )
             self.assertEqual(
-                (lower_value <= self.f1)(x, y, z, u, w, v), 1.0,
+                (lower_value <= self.f1)(x, y, z, u, v, w), 1.0,
                 msg="Callable less equals Function6D (f1() <= f2()) did not return true when it should."
             )
             self.assertEqual(
-                (ref_value <= self.f1)(x, y, z, u, w, v), 1.0,
+                (ref_value <= self.f1)(x, y, z, u, v, w), 1.0,
                 msg="Callable less equals Function6D (f1() <= f2()) did not return true when it should."
             )
             self.assertEqual(
-                (higher_value <= self.f1)(x, y, z, u, w, v), 0.0,
+                (higher_value <= self.f1)(x, y, z, u, v, w), 0.0,
                 msg="Callable less equals Function6D (f1() <= f2()) did not return false when it should."
             )
             self.assertEqual(
-                (higher_value >= self.f1)(x, y, z, u, w, v), 1.0,
+                (higher_value >= self.f1)(x, y, z, u, v, w), 1.0,
                 msg="Callable equals Function6D (f1() >= f2()) did not return true when it should."
             )
             self.assertEqual(
-                (ref_value >= self.f1)(x, y, z, u, w, v), 1.0,
+                (ref_value >= self.f1)(x, y, z, u, v, w), 1.0,
                 msg="Callable greater equals Function6D (f1() >= f2()) did not return true when it should."
             )
             self.assertEqual(
-                (lower_value >= self.f1)(x, y, z, u, w, v), 0.0,
+                (lower_value >= self.f1)(x, y, z, u, v, w), 0.0,
                 msg="Callable equals Function6D (f1() >= f2()) did not return false when it should."
             )
 
     def test_richcmp_function_function(self):
         testvals = [-1e10, -7, -0.001, 0.0, 0.00003, 10, 2.3e49]
-        for (x, y, z, u, w, v) in itertools.product(testvals, repeat=6):
+        for (x, y, z, u, v, w) in itertools.product(testvals, repeat=6):
             ref_value = self.f1
             higher_value = self.f1 + abs(self.f1) + 1
             lower_value = self.f1 - abs(self.f1) - 1
             self.assertEqual(
-                (self.f1 == ref_value)(x, y, z, u, w, v), 1.0,
+                (self.f1 == ref_value)(x, y, z, u, v, w), 1.0,
                 msg="Function6D equals Function6D (f1() == f2()) did not return true when it should."
             )
             self.assertEqual(
-                (self.f1 == higher_value)(x, y, z, u, w, v), 0.0,
+                (self.f1 == higher_value)(x, y, z, u, v, w), 0.0,
                 msg="Function6D equals Function6D (f1() == f2()) did not return false when it should."
             )
             self.assertEqual(
-                (self.f1 != higher_value)(x, y, z, u, w, v), 1.0,
+                (self.f1 != higher_value)(x, y, z, u, v, w), 1.0,
                 msg="Function6D not equals Function6D (f1() != f2()) did not return true when it should."
             )
             self.assertEqual(
-                (self.f1 != ref_value)(x, y, z, u, w, v), 0.0,
+                (self.f1 != ref_value)(x, y, z, u, v, w), 0.0,
                 msg="Function6D not equals Function6D (f1() != f2()) did not return false when it should."
             )
             self.assertEqual(
-                (self.f1 < higher_value)(x, y, z, u, w, v), 1.0,
+                (self.f1 < higher_value)(x, y, z, u, v, w), 1.0,
                 msg="Function6D less than Function6D (f1() < f2()) did not return true when it should."
             )
             self.assertEqual(
-                (self.f1 < lower_value)(x, y, z, u, w, v), 0.0,
+                (self.f1 < lower_value)(x, y, z, u, v, w), 0.0,
                 msg="Function6D less than Function6D (f1() < f2()) did not return false when it should."
             )
             self.assertEqual(
-                (self.f1 > lower_value)(x, y, z, u, w, v), 1.0,
+                (self.f1 > lower_value)(x, y, z, u, v, w), 1.0,
                 msg="Function6D greater than Function6D (f1() > f2()) did not return true when it should."
             )
             self.assertEqual(
-                (self.f1 > higher_value)(x, y, z, u, w, v), 0.0,
+                (self.f1 > higher_value)(x, y, z, u, v, w), 0.0,
                 msg="Function6D greater than Function6D (f1() > f2()) did not return false when it should."
             )
             self.assertEqual(
-                (self.f1 <= higher_value)(x, y, z, u, w, v), 1.0,
+                (self.f1 <= higher_value)(x, y, z, u, v, w), 1.0,
                 msg="Function6D less equals Function6D (f1() <= f2()) did not return true when it should."
             )
             self.assertEqual(
-                (self.f1 <= ref_value)(x, y, z, u, w, v), 1.0,
+                (self.f1 <= ref_value)(x, y, z, u, v, w), 1.0,
                 msg="Function6D less equals Function6D (f1() <= f2()) did not return true when it should."
             )
             self.assertEqual(
-                (self.f1 <= lower_value)(x, y, z, u, w, v), 0.0,
+                (self.f1 <= lower_value)(x, y, z, u, v, w), 0.0,
                 msg="Function6D less equals Function6D (f1() <= f2()) did not return false when it should."
             )
             self.assertEqual(
-                (self.f1 >= lower_value)(x, y, z, u, w, v), 1.0,
+                (self.f1 >= lower_value)(x, y, z, u, v, w), 1.0,
                 msg="Function6D equals Function6D (f1() >= f2()) did not return true when it should."
             )
             self.assertEqual(
-                (self.f1 >= ref_value)(x, y, z, u, w, v), 1.0,
+                (self.f1 >= ref_value)(x, y, z, u, v, w), 1.0,
                 msg="Function6D greater equals Function6D (f1() >= f2()) did not return true when it should."
             )
             self.assertEqual(
-                (self.f1 >= higher_value)(x, y, z, u, w, v), 0.0,
+                (self.f1 >= higher_value)(x, y, z, u, v, w), 0.0,
                 msg="Function6D equals Function6D (f1() >= f2()) did not return false when it should."
             )

--- a/cherab/core/math/function/float/function6d/tests/test_cmath.py
+++ b/cherab/core/math/function/float/function6d/tests/test_cmath.py
@@ -32,36 +32,36 @@ from cherab.core.math.function.float.function6d.autowrap import PythonFunction6D
 class TestCmath6D(unittest.TestCase):
 
     def setUp(self):
-        self.f1 = PythonFunction6D(lambda x, y, z, u, w, v: x / 10 + y + z + u/2 + w/3 + v/4)
-        self.f2 = PythonFunction6D(lambda x, y, z, u, w, v: x * x + y * y - z * z + u * u + w * w - v * v)
+        self.f1 = PythonFunction6D(lambda x, y, z, u, v, w: x / 10 + y + z + u/2 + v/3 + w/4)
+        self.f2 = PythonFunction6D(lambda x, y, z, u, v, w: x * x + y * y - z * z + u * u + v * v - w * w)
 
     def test_exp(self):
         testvals = [-10.0, -7, -0.001, 0.0, 0.00003, 10, 23.4]
-        for (x, y, z, u, w, v) in itertools.product(testvals, repeat=6):
+        for (x, y, z, u, v, w) in itertools.product(testvals, repeat=6):
             function = cmath6d.Exp6D(self.f1)
-            expected = math.exp(self.f1(x, y, z, u, w, v))
-            self.assertEqual(function(x, y, z, u, w, v), expected, "Exp6D call did not match reference value.")
+            expected = math.exp(self.f1(x, y, z, u, v, w))
+            self.assertEqual(function(x, y, z, u, v, w), expected, "Exp6D call did not match reference value.")
 
     def test_sin(self):
         testvals = [-10.0, -7, -0.001, 0.0, 0.00003, 10, 23.4]
-        for (x, y, z, u, w, v) in itertools.product(testvals, repeat=6):
+        for (x, y, z, u, v, w) in itertools.product(testvals, repeat=6):
             function = cmath6d.Sin6D(self.f1)
-            expected = math.sin(self.f1(x, y, z, u, w, v))
-            self.assertEqual(function(x, y, z, u, w, v), expected, "Sin6D call did not match reference value.")
+            expected = math.sin(self.f1(x, y, z, u, v, w))
+            self.assertEqual(function(x, y, z, u, v, w), expected, "Sin6D call did not match reference value.")
 
     def test_cos(self):
         testvals = [-10.0, -7, -0.001, 0.0, 0.00003, 10, 23.4]
-        for (x, y, z, u, w, v) in itertools.product(testvals, repeat=6):
+        for (x, y, z, u, v, w) in itertools.product(testvals, repeat=6):
             function = cmath6d.Cos6D(self.f1)
-            expected = math.cos(self.f1(x, y, z, u, w, v))
-            self.assertEqual(function(x, y, z, u, w, v), expected, "Cos6D call did not match reference value.")
+            expected = math.cos(self.f1(x, y, z, u, v, w))
+            self.assertEqual(function(x, y, z, u, v, w), expected, "Cos6D call did not match reference value.")
 
     def test_tan(self):
         testvals = [-10.0, -7, -0.001, 0.0, 0.00003, 10, 23.4]
-        for (x, y, z, u, w, v) in itertools.product(testvals, repeat=6):
+        for (x, y, z, u, v, w) in itertools.product(testvals, repeat=6):
             function = cmath6d.Tan6D(self.f1)
-            expected = math.tan(self.f1(x, y, z, u, w, v))
-            self.assertEqual(function(x, y, z, u, w, v), expected, "Tan6D call did not match reference value.")
+            expected = math.tan(self.f1(x, y, z, u, v, w))
+            self.assertEqual(function(x, y, z, u, v, w), expected, "Tan6D call did not match reference value.")
 
     def test_asin(self):
         v = [-10, -6, -2, -0.001, 0, 0.001, 2, 6, 10]
@@ -85,31 +85,31 @@ class TestCmath6D(unittest.TestCase):
 
     def test_atan(self):
         testvals = [-10.0, -7, -0.001, 0.0, 0.00003, 10, 23.4]
-        for (x, y, z, u, w, v) in itertools.product(testvals, repeat=6):
+        for (x, y, z, u, v, w) in itertools.product(testvals, repeat=6):
             function = cmath6d.Atan6D(self.f1)
-            expected = math.atan(self.f1(x, y, z, u, w, v))
-            self.assertEqual(function(x, y, z, u, w, v), expected, "Atan6D call did not match reference value.")
+            expected = math.atan(self.f1(x, y, z, u, v, w))
+            self.assertEqual(function(x, y, z, u, v, w), expected, "Atan6D call did not match reference value.")
 
     def test_atan2(self):
         testvals = [-10.0, -7, -0.001, 0.0, 0.00003, 10, 23.4]
-        for (x, y, z, u, w, v) in itertools.product(testvals, repeat=6):
+        for (x, y, z, u, v, w) in itertools.product(testvals, repeat=6):
             function = cmath6d.Atan4Q6D(self.f1, self.f2)
-            expected = math.atan2(self.f1(x, y, z, u, w, v), self.f2(x, y, z, u, w, v))
-            self.assertEqual(function(x, y, z, u, w, v), expected, "Atan4Q6D call did not match reference value.")
+            expected = math.atan2(self.f1(x, y, z, u, v, w), self.f2(x, y, z, u, v, w))
+            self.assertEqual(function(x, y, z, u, v, w), expected, "Atan4Q6D call did not match reference value.")
 
     def test_erf(self):
         testvals = [-1e5, -7, -0.001, 0.0, 0.00003, 10, 23.4, 1e5]
         function = cmath6d.Erf6D(self.f1)
-        for (x, y, z, u, w, v) in itertools.product(testvals, repeat=6):
-            expected = math.erf(self.f1(x, y, z, u, w, v))
-            self.assertAlmostEqual(function(x, y, z, u, w, v), expected, 10, "Erf6D call did not match reference value.")
+        for (x, y, z, u, v, w) in itertools.product(testvals, repeat=6):
+            expected = math.erf(self.f1(x, y, z, u, v, w))
+            self.assertAlmostEqual(function(x, y, z, u, v, w), expected, 10, "Erf6D call did not match reference value.")
 
     def test_sqrt(self):
         testvals = [0.0, 0.00003, 10, 23.4, 1e5]
         function = cmath6d.Sqrt6D(self.f1)
-        for (x, y, z, u, w, v) in itertools.product(testvals, repeat=6):
-            expected = math.sqrt(self.f1(x, y, z, u, w, v))
-            self.assertEqual(function(x, y, z, u, w, v), expected, "Sqrt6D call did not match reference value.")
+        for (x, y, z, u, v, w) in itertools.product(testvals, repeat=6):
+            expected = math.sqrt(self.f1(x, y, z, u, v, w))
+            self.assertEqual(function(x, y, z, u, v, w), expected, "Sqrt6D call did not match reference value.")
 
         with self.assertRaises(ValueError, msg="Sqrt6D did not raise a ValueError with value outside domain."):
             function(-0.1, -0.1, -0.1, -0.1, -0.1, -0.1)


### PR DESCRIPTION
This should fix the order of the `Function6D` parameters to more common `x, y, z, u, v, w`.